### PR TITLE
Catch OSError with warning if unable to remove old_models.py file

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -66,6 +66,9 @@ class Migrate:
             os.unlink(cls.get_old_model_file(app, location))
         except FileNotFoundError:
             pass
+        except OSError:
+            print(f"Warning: Unable to remove old_models file `{location}` for app {app}.")
+        
 
     @classmethod
     async def init_with_old_models(cls, config: dict, app: str, location: str):


### PR DESCRIPTION
I think this should be sufficient. This should catch the OSError, and warn the user that the file was not removed.