### PR TITLE
Catch OSError (if read-only file system)

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -65,7 +65,7 @@ class Migrate:
     def remove_old_model_file(cls, app: str, location: str):
         try:
             os.unlink(cls.get_old_model_file(app, location))
-        except FileNotFoundError:
+        except (OSError, FileNotFoundError):
             pass
 
     @classmethod


### PR DESCRIPTION
This should catch all OSErrors, if aerich is being run in a read-only file system.