### PR TITLE
Allow embedded use of Aerich

### DIFF
--- a/aerich/actions.py
+++ b/aerich/actions.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from aerich.output import Output
+from aerich.utils import get_models_describe, write_version_file
+
+from aerich.models import Aerich
+
+from aerich.migrate import Migrate
+from tortoise import generate_schema_for_client, BaseDBAsyncClient
+from tortoise.utils import get_schema_sql
+
+
+async def init_db_action(
+    app_name: str,
+    location: str,
+    connection: BaseDBAsyncClient,
+    output: Output,
+    safe: bool = True,
+) -> bool:
+    dirname = Path(location, app_name)
+
+    try:
+        dirname.mkdir(parents=True)
+        output.success(f"Success create app migrate location {dirname}")
+    except FileExistsError:
+        output.warning(f"Inited {app_name} already, or delete {dirname} and try again.")
+        return False
+
+    await generate_schema_for_client(connection, safe)
+
+    schema = get_schema_sql(connection, safe)
+
+    Migrate.app = app_name
+
+    version = await Migrate.generate_version()
+
+    await Aerich.create(
+        version=version, app=app_name, content=get_models_describe(app_name),
+    )
+
+    content = {
+        "upgrade": [schema],
+    }
+    write_version_file(Path(dirname, version), content)
+
+    output.success(f'Success generate schema for app "{app_name}"')
+
+    return True

--- a/aerich/actions.py
+++ b/aerich/actions.py
@@ -1,19 +1,23 @@
 from pathlib import Path
 
+from tortoise.exceptions import OperationalError
+from tortoise.transactions import in_transaction
+
 from aerich.output import Output
-from aerich.utils import get_models_describe, write_version_file
+from aerich.utils import get_models_describe, write_version_file, get_version_content_from_file
 
 from aerich.models import Aerich
 
 from aerich.migrate import Migrate
-from tortoise import generate_schema_for_client, BaseDBAsyncClient
+from tortoise import generate_schema_for_client
 from tortoise.utils import get_schema_sql
 
 
 async def init_db_action(
-    app_name: str, location: str, connection: BaseDBAsyncClient, output: Output, safe: bool = True,
+    app_name: str, location: str, connection_name: str, output: Output, safe: bool = True,
 ) -> bool:
     dirname = Path(location, app_name)
+    Migrate.app = app_name
 
     try:
         dirname.mkdir(parents=True)
@@ -22,23 +26,47 @@ async def init_db_action(
         output.warning(f"Inited {app_name} already, or delete {dirname} and try again.")
         return False
 
-    await generate_schema_for_client(connection, safe)
+    async with in_transaction(connection_name) as conn:
+        await generate_schema_for_client(conn, safe)
 
-    schema = get_schema_sql(connection, safe)
+        schema = get_schema_sql(conn, safe)
 
-    Migrate.app = app_name
+        version = await Migrate.generate_version()
 
-    version = await Migrate.generate_version()
+        await Aerich.create(
+            version=version, app=app_name, content=get_models_describe(app_name),
+        )
 
-    await Aerich.create(
-        version=version, app=app_name, content=get_models_describe(app_name),
-    )
+        content = {
+            "upgrade": [schema],
+        }
+        write_version_file(Path(dirname, version), content)
 
-    content = {
-        "upgrade": [schema],
-    }
-    write_version_file(Path(dirname, version), content)
-
-    output.success(f'Success generate schema for app "{app_name}"')
+        output.success(f'Success generate schema for app "{app_name}"')
 
     return True
+
+
+async def upgrade_action(app_name: str, location: str, connection_name: str, output: Output):
+    migrated = False
+    Migrate.app = app_name
+    Migrate.migrate_location = Path(location, app_name)
+    for version_file in Migrate.get_all_version_files():
+        try:
+            exists = await Aerich.exists(version=version_file, app=app_name)
+        except OperationalError:
+            exists = False
+        if not exists:
+            async with in_transaction(connection_name) as conn:
+                file_path = Path(Migrate.migrate_location, version_file)
+                content = get_version_content_from_file(file_path)
+                upgrade_query_list = content.get("upgrade")
+                for upgrade_query in upgrade_query_list:
+                    await conn.execute_script(upgrade_query)
+                await Aerich.create(
+                    version=version_file, app=app_name, content=get_models_describe(app_name),
+                )
+            output.success(f"Success upgrade {version_file}")
+            migrated = True
+    if not migrated:
+        output.warning("No upgrade items found")

--- a/aerich/actions.py
+++ b/aerich/actions.py
@@ -11,11 +11,7 @@ from tortoise.utils import get_schema_sql
 
 
 async def init_db_action(
-    app_name: str,
-    location: str,
-    connection: BaseDBAsyncClient,
-    output: Output,
-    safe: bool = True,
+    app_name: str, location: str, connection: BaseDBAsyncClient, output: Output, safe: bool = True,
 ) -> bool:
     dirname = Path(location, app_name)
 

--- a/aerich/embed.py
+++ b/aerich/embed.py
@@ -1,5 +1,3 @@
-from tortoise import Tortoise
-
 from aerich.actions import init_db_action, upgrade_action
 from aerich.output import PrintOutput, Output
 

--- a/aerich/embed.py
+++ b/aerich/embed.py
@@ -1,6 +1,6 @@
 from tortoise import Tortoise
 
-from aerich.actions import init_db_action
+from aerich.actions import init_db_action, upgrade_action
 from aerich.output import PrintOutput, Output
 
 
@@ -18,11 +18,18 @@ class Aerich:
         self.__output = output or PrintOutput()
 
     async def init_db(self, safe: bool = True) -> bool:
-        connection = Tortoise.get_connection(connection_name=self.__connection_name)
         await init_db_action(
             app_name=self.__app_name,
             location=self.__location,
-            connection=connection,
+            connection_name=self.__connection_name,
             output=self.__output,
             safe=safe,
+        )
+
+    async def upgrade(self) -> bool:
+        await upgrade_action(
+            app_name=self.__app_name,
+            location=self.__location,
+            connection_name=self.__connection_name,
+            output=self.__output,
         )

--- a/aerich/embed.py
+++ b/aerich/embed.py
@@ -1,0 +1,28 @@
+from tortoise import Tortoise
+
+from aerich.actions import init_db_action
+from aerich.output import PrintOutput, Output
+
+
+class Aerich:
+    def __init__(
+        self,
+        app_name: str = "models",
+        location: str = "migrations",
+        connection_name: str = "default",
+        output: Output = None,
+    ):
+        self.__app_name = app_name
+        self.__location = location
+        self.__connection_name = connection_name
+        self.__output = output or PrintOutput()
+
+    async def init_db(self, safe: bool = True) -> bool:
+        connection = Tortoise.get_connection(connection_name=self.__connection_name)
+        await init_db_action(
+            app_name=self.__app_name,
+            location=self.__location,
+            connection=connection,
+            output=self.__output,
+            safe=safe,
+        )

--- a/aerich/output.py
+++ b/aerich/output.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+
+import click
+from aerich.enums import Color
+
+
+class Output(ABC):
+    @abstractmethod
+    def success(self, message: str):
+        pass
+
+    @abstractmethod
+    def warning(self, message: str):
+        pass
+
+
+class ClickOutput(Output):
+    def success(self, message: str):
+        click.secho(message, Color.green)
+
+    def warning(self, message: str):
+        click.secho(message, Color.yellow)
+
+
+class PrintOutput(Output):
+    def success(self, message: str):
+        print(message)
+
+    def warning(self, message: str):
+        print(f"WARNING: {message}")

--- a/aerich/output.py
+++ b/aerich/output.py
@@ -16,10 +16,10 @@ class Output(ABC):
 
 class ClickOutput(Output):
     def success(self, message: str):
-        click.secho(message, Color.green)
+        click.secho(message, fg=Color.green)
 
     def warning(self, message: str):
-        click.secho(message, Color.yellow)
+        click.secho(message, fg=Color.yellow)
 
 
 class PrintOutput(Output):


### PR DESCRIPTION
Related to #141 

@long2ice this is far from complete, but I wanted to share with you the approach I was thinking.

I'm no expert in either Tortoise or Aerich, so please bear with me.

This is the sample program I'm using to call the init_db from inside the application. The application takes care of setting up the DB connection, and providing it to Aerich. In the CLI case, the CLI is in charge of doing that.

```
import asyncio

from tortoise import Tortoise
from aerich.embed import Aerich

from app.models import Team

db_url = "sqlite:///tmp/dummy.sqlite3"

TORTOISE_ORM = {
    "connections": {"default": db_url},
    "apps": {
        "models": {
            "models": ["app.models", "aerich.models"],
            "default_connection": "default",
        },
    },
}


async def run():
    await Tortoise.init(
        db_url=db_url,
        modules={'models': ['app.models', 'aerich.models']}
    )

    # Generate the schema
    await Tortoise.generate_schemas()

    aerich = Aerich()
    await aerich.init_db()
    await aerich.upgrade()

    print(await Team.all().values_list("name", flat=True))

    await Tortoise.close_connections()


def main():
    asyncio.get_event_loop().run_until_complete(run())


if __name__ == "__main__":
    main()
```