### PR TITLE
Increase max length of app column

### DIFF
--- a/aerich/models.py
+++ b/aerich/models.py
@@ -3,11 +3,12 @@ from tortoise import Model, fields
 from aerich.coder import decoder, encoder
 
 MAX_VERSION_LENGTH = 255
+MAX_APP_LENGTH = 100
 
 
 class Aerich(Model):
     version = fields.CharField(max_length=MAX_VERSION_LENGTH)
-    app = fields.CharField(max_length=20)
+    app = fields.CharField(max_length=MAX_APP_LENGTH)
     content = fields.JSONField(encoder=encoder, decoder=decoder)
 
     class Meta:


### PR DESCRIPTION
Relatively short application names with prefixes of environments or namespaces do not meet the requirements of 20 characters. I find it useful to expand the maximum number of characters.