### PR TITLE
Close connections in the init_db wrapper

### DIFF
--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -30,7 +30,7 @@ def coro(f):
         try:
             loop.run_until_complete(f(*args, **kwargs))
         finally:
-            if f.__name__ not in ["cli", "init_db", "init"]:
+            if f.__name__ not in ["cli", "init"]:
                 loop.run_until_complete(Tortoise.close_connections())
 
     return wrapper


### PR DESCRIPTION
This PR fixes #268

Since `init_db` connects to database we need to close all connections for graceful shutdown.