### PR TITLE
add char support for mysql

### DIFF
--- a/aerich/inspectdb/mysql.py
+++ b/aerich/inspectdb/mysql.py
@@ -12,6 +12,7 @@ class InspectMySQL(Inspect):
             "tinyint": self.bool_field,
             "bigint": self.bigint_field,
             "varchar": self.char_field,
+            "char": self.char_field,
             "longtext": self.text_field,
             "text": self.text_field,
             "datetime": self.datetime_field,


### PR DESCRIPTION
Support added for [Char](https://dev.mysql.com/doc/refman/8.0/en/char.html) datatype for MySQL. This datatype was mapped to the _classmethod_ `self.char_field`, which is the same as `varchar` type.