### PR TITLE
add: able to specify init_db file name

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -126,7 +126,7 @@ class Command:
     async def migrate(self, name: str = "update"):
         return await Migrate.migrate(name)
 
-    async def init_db(self, safe: bool):
+    async def init_db(self, safe: bool, name: str = "init"):
         location = self.location
         app = self.app
         dirname = Path(location, app)
@@ -138,7 +138,7 @@ class Command:
 
         schema = get_schema_sql(connection, safe)
 
-        version = await Migrate.generate_version()
+        version = await Migrate.generate_version(name)
         await Aerich.create(
             version=version,
             app=app,


### PR DESCRIPTION
Thanks for the utility! I made some small change, hope this is useful. Motivation was that originaly database init file generated with `None` name like `2_20230621081041_None.py`.