### PR TITLE
Add `__eq__` method for `Index` instances

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -173,10 +173,17 @@ class Migrate:
         ret = []
         for index in indexes:
             if isinstance(index, Index):
-                index.__hash__ = lambda self: md5(  # nosec: B303
-                    self.index_name(cls.ddl.schema_generator, model).encode()
-                    + self.__class__.__name__.encode()
-                ).hexdigest()
+                def add_hash_eq_methods_to_index(idx):
+                    def _hash(self):
+                        return hash(self.index_name(cls.ddl.schema_generator, model).encode() + self.__class__.__name__.encode())
+
+                    def _eq(self, other):
+                        return self.__hash__() == other.__hash__()
+
+                    setattr(idx.__class__, '__hash__', _hash)
+                    setattr(idx.__class__, '__eq__', _eq)
+                    return idx
+                index = add_hash_eq_methods_to_index(index)                
             ret.append(index)
         return ret
 


### PR DESCRIPTION
Fix https://github.com/tortoise/aerich/issues/258

This issue happens because `new_indexes.difference(old_indexes)` [[code](https://github.com/tortoise/aerich/blob/dev/aerich/migrate.py#L280-L281)] and `old_indexes.difference(new_indexes)` [[code](https://github.com/tortoise/aerich/blob/dev/aerich/migrate.py#L283-L284)] returns always all indexes, even when they are equal. 

This PR fixes this by adding the `__eq__` to all `Index` instances. To ensure that indexes are equal we compare them using the `__hash__` method.
