### PR TITLE
Update poetry build backend to support editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ location = "./migrations"
 src_folder = "./."
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 aerich = "aerich.cli:main"


### PR DESCRIPTION
## Summary

Updated build backend to support editable install.

## Reason

Old poetry builder does not support editable install.

## Before

```
❯ pip install -e ../../aerich/
Obtaining file:///<...>/aerich
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
ERROR: Project file:///<...>/aerich has a 'pyproject.toml' and its build backend is missing the 
'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed 
in editable mode. Consider using a build backend that supports PEP 660.
```

## After

```
❯ pip install -e ../../aerich/
Obtaining file:///<...>/aerich
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
...
Successfully built aerich
Installing collected packages: aerich
Successfully installed aerich-0.7.2
```
