### PR TITLE
Fix changed column descriptions in diffs

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -486,6 +486,9 @@ class Migrate:
                         elif option == "nullable":
                             # change nullable
                             cls._add_operator(cls._alter_null(model, new_data_field), upgrade)
+                        elif option == "description":
+                            # change comment
+                            cls._add_operator(cls._set_comment(model, new_data_field), upgrade)
                         else:
                             if modified:
                                 continue


### PR DESCRIPTION
## Summary

Detect changes in column descriptions.

## Bug

On each enum change linked to EnumField aerich generates useless `ALTER TABLE`.

## Steps to reproduce

1. create model with EnumField
2. aerich init-db
3. add field to enum
4. aerich migrate
5. check new migration

## Before

```
async def upgrade(db: BaseDBAsyncClient) -> str:
    return """
        ALTER TABLE "somemodel" ALTER COLUMN "field" TYPE VARCHAR(6) USING "field"::VARCHAR(6);"""


async def downgrade(db: BaseDBAsyncClient) -> str:
    return """
        ALTER TABLE "somemodel" ALTER COLUMN "field" TYPE VARCHAR(6) USING "field"::VARCHAR(6);"""
```


## After

```
async def upgrade(db: BaseDBAsyncClient) -> str:
    return """
        COMMENT ON COLUMN "somemodel"."field" IS 'VALUE1: VALUE1
VALUE2: VALUE2
VALUE3: VALUE3';"""


async def downgrade(db: BaseDBAsyncClient) -> str:
    return """
        COMMENT ON COLUMN "somemodel"."field" IS 'VALUE1: VALUE1
VALUE2: VALUE2';"""
```
