### PR TITLE
Added an option to generate empty migration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ If `aerich` guesses you are renaming a column, it will ask `Rename {old_column} 
 `True` to rename column without column drop, or choose `False` to drop the column then create. Note that the latter may
 lose data.
 
+If you need to manually write migration, you could generate empty file:
+
+```shell
+> aerich migrate --name add_index --empty
+
+Success migrate 1_202326122220101229_add_index.py
+```
+
 ### Upgrade to latest version
 
 ```shell

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -123,8 +123,8 @@ class Command:
         inspect = cls(connection, tables)
         return await inspect.inspect()
 
-    async def migrate(self, name: str = "update"):
-        return await Migrate.migrate(name)
+    async def migrate(self, name: str = "update", empty: bool = False) -> str:
+        return await Migrate.migrate(name, empty)
 
     async def init_db(self, safe: bool):
         location = self.location

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -79,6 +79,7 @@ async def cli(ctx: Context, config, app):
 
 @cli.command(help="Generate migrate changes file.")
 @click.option("--name", default="update", show_default=True, help="Migrate name.")
+@click.option("--empty", default=False, is_flag=True, help="Generate empty migration file.")
 @click.pass_context
 @coro
 async def migrate(ctx: Context, name):

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -120,10 +120,7 @@ class Migrate:
                 os.unlink(Path(cls.migrate_location, version_file))
 
         version_file = Path(cls.migrate_location, version)
-        content = MIGRATE_TEMPLATE.format(
-            upgrade_sql=";\n        ".join(cls.upgrade_operators) + ";",
-            downgrade_sql=";\n        ".join(cls.downgrade_operators) + ";",
-        )
+        content = cls._get_diff_file_content()
 
         with open(version_file, "w", encoding="utf-8") as f:
             f.write(content)
@@ -150,6 +147,21 @@ class Migrate:
             return ""
 
         return await cls._generate_diff_py(name)
+
+    @classmethod
+    def _get_diff_file_content(cls) -> str:
+        """
+        builds content for diff file from template
+        """
+        def join_lines(lines: List[str]) -> str:
+            if not lines:
+                return ""
+            return ";\n        ".join(lines) + ";"
+            
+        return MIGRATE_TEMPLATE.format(
+            upgrade_sql=join_lines(cls.upgrade_operators), 
+            downgrade_sql=join_lines(cls.downgrade_operators)
+        )
 
     @classmethod
     def _add_operator(cls, operator: str, upgrade=True, fk_m2m_index=False):

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -130,12 +130,16 @@ class Migrate:
         return version
 
     @classmethod
-    async def migrate(cls, name) -> str:
+    async def migrate(cls, name: str, empty: bool) -> str:
         """
         diff old models and new models to generate diff content
-        :param name:
+        :param name: str name for migration
+        :param empty: bool if True generates empty migration
         :return:
         """
+        if empty:
+            return await cls._generate_diff_py(name)
+
         new_version_content = get_models_describe(cls.app)
         cls.diff_models(cls._last_version_content, new_version_content)
         cls.diff_models(new_version_content, cls._last_version_content, False)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -973,7 +973,7 @@ def test_sort_all_version_files(mocker):
 async def test_empty_migration(mocker) -> None:
     mocker.patch("os.listdir", return_value=[])
     Migrate.app = "foo"
-    expected_content = MIGRATE_TEMPLATE.format(upgrade_sql=";", downgrade_sql=";")
+    expected_content = MIGRATE_TEMPLATE.format(upgrade_sql="", downgrade_sql="")
     with tempfile.TemporaryDirectory() as temp_dir:
         Migrate.migrate_location = temp_dir
 


### PR DESCRIPTION
I needed to add some manual migrations and didn't find how to generate empty file. I think it might be useful for somebody else.  

Related issue [#101](https://github.com/tortoise/aerich/issues/101)