### PR TITLE
Fix the issue of parameter concatenation when generating ORM with ins…

### DIFF
--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -36,7 +36,7 @@ class Column(BaseModel):
                 length_parts.append(f"max_digits={self.max_digits}")
             if self.decimal_places:
                 length_parts.append(f"decimal_places={self.decimal_places}")
-            length = ", ".join(length_parts)
+            length = ", ".join(length_parts)+", "
         if self.null:
             null = "null=True, "
         if self.default is not None:


### PR DESCRIPTION
Before fixing the parameter concatenation:
d_price = 
fields.DecimalField(max_digits=10, decimal_places=2null=True, )
p_price = 
fields.DecimalField(max_digits=10, decimal_places=2null=True, )

After fixing the parameter concatenation:
d_price = 
fields.DecimalField(max_digits=10, decimal_places=2, null=True, )
p_price = 
fields.DecimalField(max_digits=10, decimal_places=2, null=True, )