### PR TITLE
Improve CLI help text and output

### DIFF
--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -69,7 +69,7 @@ async def migrate(ctx: Context, name, empty) -> None:
     ret = await command.migrate(name, empty)
     if not ret:
         return click.secho("No changes detected", fg=Color.yellow)
-    click.secho(f"Successfully created migration file {ret}", fg=Color.green)
+    click.secho(f"Success creating migration file {ret}", fg=Color.green)
 
 
 @cli.command(help="Upgrade to specified migration version.")


### PR DESCRIPTION
Changed the help text for some of the command-line options, and the output of the commands, to be more clear and consistent.

A few of the options I wasn't totally sure what they do, so please review to make sure the text says the correct thing.