### PR TITLE
Improve type hints of inspectdb

### DIFF
--- a/aerich/inspectdb/mysql.py
+++ b/aerich/inspectdb/mysql.py
@@ -1,11 +1,11 @@
-from typing import List
+from __future__ import annotations
 
-from aerich.inspectdb import Column, Inspect
+from aerich.inspectdb import Column, FieldMapDict, Inspect
 
 
 class InspectMySQL(Inspect):
     @property
-    def field_map(self) -> dict:
+    def field_map(self) -> FieldMapDict:
         return {
             "int": self.int_field,
             "smallint": self.smallint_field,
@@ -24,12 +24,12 @@ class InspectMySQL(Inspect):
             "longblob": self.binary_field,
         }
 
-    async def get_all_tables(self) -> List[str]:
+    async def get_all_tables(self) -> list[str]:
         sql = "select TABLE_NAME from information_schema.TABLES where TABLE_SCHEMA=%s"
         ret = await self.conn.execute_query_dict(sql, [self.database])
         return list(map(lambda x: x["TABLE_NAME"], ret))
 
-    async def get_columns(self, table: str) -> List[Column]:
+    async def get_columns(self, table: str) -> list[Column]:
         columns = []
         sql = """select c.*, s.NON_UNIQUE, s.INDEX_NAME
 from information_schema.COLUMNS c

--- a/aerich/inspectdb/sqlite.py
+++ b/aerich/inspectdb/sqlite.py
@@ -1,11 +1,11 @@
-from typing import Callable, Dict, List
+from __future__ import annotations
 
-from aerich.inspectdb import Column, Inspect
+from aerich.inspectdb import Column, FieldMapDict, Inspect
 
 
 class InspectSQLite(Inspect):
     @property
-    def field_map(self) -> Dict[str, Callable[..., str]]:
+    def field_map(self) -> FieldMapDict:
         return {
             "INTEGER": self.int_field,
             "INT": self.bool_field,
@@ -21,7 +21,7 @@ class InspectSQLite(Inspect):
             "BLOB": self.binary_field,
         }
 
-    async def get_columns(self, table: str) -> List[Column]:
+    async def get_columns(self, table: str) -> list[Column]:
         columns = []
         sql = f"PRAGMA table_info({table})"
         ret = await self.conn.execute_query_dict(sql)
@@ -45,7 +45,7 @@ class InspectSQLite(Inspect):
             )
         return columns
 
-    async def _get_columns_index(self, table: str) -> Dict[str, str]:
+    async def _get_columns_index(self, table: str) -> dict[str, str]:
         sql = f"PRAGMA index_list ({table})"
         indexes = await self.conn.execute_query_dict(sql)
         ret = {}
@@ -55,7 +55,7 @@ class InspectSQLite(Inspect):
             ret[index_info["name"]] = "unique" if index["unique"] else "index"
         return ret
 
-    async def get_all_tables(self) -> List[str]:
+    async def get_all_tables(self) -> list[str]:
         sql = "select tbl_name from sqlite_master where type='table' and name!='sqlite_sequence'"
         ret = await self.conn.execute_query_dict(sql)
         return list(map(lambda x: x["tbl_name"], ret))


### PR DESCRIPTION
1. Improve type hints
2. Fix style issue that introduce by #331
3. Check that `length_parts` is not empty before change value of var `length` in [`aerich.inspectedb.Column.translate`](https://github.com/waketzheng/aerich/blob/type-hints/aerich/inspectdb/__init__.py#L54)