### PR TITLE
tests: no need to merge operators when NotSupportError raised

### DIFF
--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -864,7 +864,7 @@ def test_migrate(mocker: MockerFixture):
     else:
         Migrate.diff_models(old_models_describe, models_describe)
         Migrate.diff_models(models_describe, old_models_describe, False)
-    Migrate._merge_operators()
+        Migrate._merge_operators()
     if isinstance(Migrate.ddl, MysqlDDL):
         expected_upgrade_operators = {
             "ALTER TABLE `category` MODIFY COLUMN `name` VARCHAR(200)",


### PR DESCRIPTION
Action https://github.com/tortoise/aerich/actions/runs/12142921728/job/33858554690 failed with the following info:
```
>           assert Migrate.upgrade_operators == []
E           assert ['ALTER TABLE...itle_f7fc03"'] == []
E             
E             Left contains one more item: 'ALTER TABLE "category" DROP INDEX "uid_category_title_f7fc03"'
E             
E             Full diff:
E             - []
E             + [
E             +     'ALTER TABLE "category" DROP INDEX "uid_category_title_f7fc03"',
E             + ]

tests/test_migrate.py:1038: AssertionError
=========================== short test summary info ============================
FAILED tests/test_migrate.py::test_migrate - assert ['ALTER TABLE...itle_f7fc03"'] == []
  
  Left contains one more item: 'ALTER TABLE "category" DROP INDEX "uid_category_title_f7fc03"'
  
  Full diff:
  - []
  + [
  +     'ALTER TABLE "category" DROP INDEX "uid_category_title_f7fc03"',
  + ]
========================= 1 failed, 15 passed in 0.25s =========================
make: *** [Makefile:36: test_sqlite] Error 1
```
That is because the ALTER operator add to class var of Migrate before NotSupportError raised.

Resolve it by move the `Migrate._merge_operators()` to only run in case of ddl is not sqlite. 