### PR TITLE
fix: migrate drop the wrong m2m field when model have multi m2m fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.1](Unreleased)
 
 #### Fixed
+- Migrate drop the wrong m2m field when model have multi m2m fields. (#376)
 - Sort m2m fields before comparing them with diff. (#271)
 
 ### [0.8.0](../../releases/tag/v0.8.0) - 2024-12-04

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -13,7 +13,12 @@ from tortoise.indexes import Index
 
 from aerich.ddl import BaseDDL
 from aerich.models import MAX_VERSION_LENGTH, Aerich
-from aerich.utils import get_app_connection, get_models_describe, is_default_function
+from aerich.utils import (
+    get_app_connection,
+    get_models_describe,
+    is_default_function,
+    reorder_m2m_fields,
+)
 
 MIGRATE_TEMPLATE = """from tortoise import BaseDBAsyncClient
 
@@ -271,10 +276,8 @@ class Migrate:
                 # m2m fields
                 old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
                 new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
-                if old_m2m_fields and len(new_m2m_fields) >= 2:
-                    length = len(old_m2m_fields)
-                    field_index = {f["name"]: i for i, f in enumerate(new_m2m_fields)}
-                    new_m2m_fields.sort(key=lambda field: field_index.get(field["name"], length))
+                if old_m2m_fields and new_m2m_fields:
+                    reorder_m2m_fields(old_m2m_fields, new_m2m_fields)
                 for action, _, change in diff(old_m2m_fields, new_m2m_fields):
                     if change[0][0] == "db_constraint":
                         continue

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -277,7 +277,9 @@ class Migrate:
                 old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
                 new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
                 if old_m2m_fields and new_m2m_fields:
-                    reorder_m2m_fields(old_m2m_fields, new_m2m_fields)
+                    old_m2m_fields, new_m2m_fields = reorder_m2m_fields(
+                        old_m2m_fields, new_m2m_fields
+                    )
                 for action, _, change in diff(old_m2m_fields, new_m2m_fields):
                     if change[0][0] == "db_constraint":
                         continue

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -105,32 +105,110 @@ def import_py_file(file: Union[str, Path]) -> ModuleType:
     return module
 
 
-def reorder_m2m_fields(old_m2m_fields: list[dict], new_m2m_fields: list[dict]) -> None:
+def _pick_match_to_head(m2m_fields: list[dict], field_info: dict) -> list[dict]:
+    """
+    If there is a element in m2m_fields whose through or name is equal to field_info's
+    and this element is not at the first position, put it to the head then return the
+    new list, otherwise return the origin list.
+
+    Example::
+        >>> m2m_fields = [{'through': 'u1', 'name': 'u1'}, {'throught': 'u2', 'name': 'u2'}]
+        >>> _pick_match_to_head(m2m_fields, {'through': 'u2', 'name': 'u2'})
+        [{'through': 'u2', 'name': 'u2'}, {'throught': 'u1', 'name': 'u1'}]
+
+    """
+    through = field_info["through"]
+    name = field_info["name"]
+    for index, field in enumerate(m2m_fields):
+        if field["through"] == through or field["name"] == name:
+            if index != 0:
+                m2m_fields = [field, *m2m_fields[:index], *m2m_fields[index + 1 :]]
+            break
+    return m2m_fields
+
+
+def reorder_m2m_fields(
+    old_m2m_fields: list[dict], new_m2m_fields: list[dict]
+) -> tuple[list[dict], list[dict]]:
     """
     Reorder m2m fields to help dictdiffer.diff generate more precise changes
     :param old_m2m_fields: previous m2m field info list
     :param new_m2m_fields: current m2m field info list
-    :return:
+    :return: ordered old/new m2m fields
     """
-    old_table_names: list[str] = [f["through"] for f in old_m2m_fields]
-    new_table_names: list[str] = [f["through"] for f in new_m2m_fields]
-    if old_table_names == new_table_names:
-        return
-    if sorted(old_table_names) == sorted(new_table_names):
-        new_m2m_fields.sort(key=lambda field: old_table_names.index(field["through"]))
-        return
-    old_field_names: list[str] = [f["name"] for f in old_m2m_fields]
-    new_field_names: list[str] = [f["name"] for f in new_m2m_fields]
-    if old_field_names == new_field_names:
-        return
-    if sorted(old_field_names) == sorted(new_field_names):
-        new_m2m_fields.sort(key=lambda field: old_field_names.index(field["name"]))
-        return
-    if unchanged_tables := set(old_table_names) & set(new_table_names):
-        unchanged = sorted(unchanged_tables)
-        ordered_old_tables = unchanged + sorted(set(old_table_names) - unchanged_tables)
-        ordered_new_tables = unchanged + sorted(set(new_table_names) - unchanged_tables)
-        if ordered_old_tables != old_table_names:
-            old_m2m_fields.sort(key=lambda field: ordered_old_tables.index(field["through"]))
-        if ordered_new_tables != new_table_names:
-            new_m2m_fields.sort(key=lambda field: ordered_new_tables.index(field["through"]))
+    length_old, length_new = len(old_m2m_fields), len(new_m2m_fields)
+    if length_old == length_new == 1:
+        # No need to change order if both of them have only one element
+        pass
+    elif length_old == 1:
+        # If any element of new fields match the one in old fields, put it to head
+        new_m2m_fields = _pick_match_to_head(new_m2m_fields, old_m2m_fields[0])
+    elif length_new == 1:
+        old_m2m_fields = _pick_match_to_head(old_m2m_fields, new_m2m_fields[0])
+    else:
+        old_table_names = [f["through"] for f in old_m2m_fields]
+        new_table_names = [f["through"] for f in new_m2m_fields]
+        old_field_names = [f["name"] for f in old_m2m_fields]
+        new_field_names = [f["name"] for f in new_m2m_fields]
+        if old_table_names == new_table_names:
+            pass
+        elif sorted(old_table_names) == sorted(new_table_names):
+            # If table name are the same but order not match,
+            # reorder new fields by through to match the order of old.
+
+            # Case like::
+            # old_m2m_fields = [
+            #     {'through': 'users_group', 'name': 'users',},
+            #     {'through': 'admins_group', 'name': 'admins'},
+            # ]
+            # new_m2m_fields = [
+            #     {'through': 'admins_group', 'name': 'admins_new'},
+            #     {'through': 'users_group', 'name': 'users_new',},
+            # ]
+            new_m2m_fields = sorted(
+                new_m2m_fields, key=lambda f: old_table_names.index(f["through"])
+            )
+        elif old_field_names == new_field_names:
+            pass
+        elif sorted(old_field_names) == sorted(new_field_names):
+            # Case like:
+            # old_m2m_fields = [
+            #     {'name': 'users', 'through': 'users_group'},
+            #     {'name': 'admins', 'through': 'admins_group'},
+            # ]
+            # new_m2m_fields = [
+            #     {'name': 'admins', 'through': 'admin_group_map'},
+            #     {'name': 'users', 'through': 'user_group_map'},
+            # ]
+            new_m2m_fields = sorted(new_m2m_fields, key=lambda f: old_field_names.index(f["name"]))
+        elif unchanged_table_names := set(old_table_names) & set(new_table_names):
+            # If old/new m2m field list have one or some unchanged table names, put them to head of list.
+
+            # Case like::
+            # old_m2m_fields = [
+            #     {'through': 'users_group', 'name': 'users',},
+            #     {'through': 'staffs_group', 'name': 'users',},
+            #     {'through': 'admins_group', 'name': 'admins'},
+            # ]
+            # new_m2m_fields = [
+            #     {'through': 'admins_group', 'name': 'admins_new'},
+            #     {'through': 'users_group', 'name': 'users_new',},
+            # ]
+            unchanged = sorted(unchanged_table_names, key=lambda name: old_table_names.index(name))
+            ordered_old_tables = unchanged + sorted(
+                set(old_table_names) - unchanged_table_names,
+                key=lambda name: old_table_names.index(name),
+            )
+            ordered_new_tables = unchanged + sorted(
+                set(new_table_names) - unchanged_table_names,
+                key=lambda name: new_table_names.index(name),
+            )
+            if ordered_old_tables != old_table_names:
+                old_m2m_fields = sorted(
+                    old_m2m_fields, key=lambda f: ordered_old_tables.index(f["through"])
+                )
+            if ordered_new_tables != new_table_names:
+                new_m2m_fields = sorted(
+                    new_m2m_fields, key=lambda f: ordered_new_tables.index(f["through"])
+                )
+    return old_m2m_fields, new_m2m_fields

--- a/tests/models.py
+++ b/tests/models.py
@@ -78,6 +78,9 @@ class Product(Model):
 
 
 class Config(Model):
+    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField(
+        "models.Category", through="config_category_map", related_name="category_set"
+    )
     label = fields.CharField(max_length=200)
     key = fields.CharField(max_length=20)
     value: dict = fields.JSONField()

--- a/tests/old_models.py
+++ b/tests/old_models.py
@@ -65,6 +65,10 @@ class Product(Model):
 
 
 class Config(Model):
+    category: fields.ManyToManyRelation[Category] = fields.ManyToManyField("models.Category")
+    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField(
+        "models.Category", through="config_category_map", related_name="config_set"
+    )
     name = fields.CharField(max_length=100, unique=True)
     label = fields.CharField(max_length=200)
     key = fields.CharField(max_length=20)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1076,7 +1076,8 @@ def test_migrate(mocker: MockerFixture):
             'DROP INDEX "uid_product_name_869427"',
             'DROP TABLE IF EXISTS "email_user"',
             'DROP TABLE IF EXISTS "newmodel"',
-            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)', 'DROP TABLE IF EXISTS "config_category_map"'
+            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)',
+            'DROP TABLE IF EXISTS "config_category_map"',
         }
         if should_add_user_id_column_type_alter_sql():
             sql = 'ALTER TABLE "category" ALTER COLUMN "user_id" TYPE INT USING "user_id"::INT'

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -268,7 +268,48 @@ old_models_describe = {
         "backward_fk_fields": [],
         "o2o_fields": [],
         "backward_o2o_fields": [],
-        "m2m_fields": [],
+        "m2m_fields": [
+            {
+                "name": "category",
+                "field_type": "ManyToManyFieldInstance",
+                "python_type": "models.Category",
+                "generated": False,
+                "nullable": False,
+                "unique": False,
+                "indexed": False,
+                "default": None,
+                "description": None,
+                "docstring": None,
+                "constraints": {},
+                "model_name": "models.Category",
+                "related_name": "configs",
+                "forward_key": "category_id",
+                "backward_key": "config_id",
+                "through": "config_category",
+                "on_delete": "CASCADE",
+                "_generated": False,
+            },
+            {
+                "name": "categories",
+                "field_type": "ManyToManyFieldInstance",
+                "python_type": "models.Category",
+                "generated": False,
+                "nullable": False,
+                "unique": False,
+                "indexed": False,
+                "default": None,
+                "description": None,
+                "docstring": None,
+                "constraints": {},
+                "model_name": "models.Category",
+                "related_name": "config_set",
+                "forward_key": "category_id",
+                "backward_key": "config_id",
+                "through": "config_category_map",
+                "on_delete": "CASCADE",
+                "_generated": False,
+            },
+        ],
     },
     "models.Email": {
         "name": "models.Email",
@@ -904,6 +945,8 @@ def test_migrate(mocker: MockerFixture):
             "ALTER TABLE `product` MODIFY COLUMN `body` LONGTEXT NOT NULL",
             "ALTER TABLE `email` MODIFY COLUMN `is_primary` BOOL NOT NULL  DEFAULT 0",
             "CREATE TABLE `product_user` (\n    `product_id` INT NOT NULL REFERENCES `product` (`id`) ON DELETE CASCADE,\n    `user_id` INT NOT NULL REFERENCES `user` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "CREATE TABLE `config_category_map` (\n    `category_id` INT NOT NULL REFERENCES `category` (`id`) ON DELETE CASCADE,\n    `config_id` INT NOT NULL REFERENCES `config` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "DROP TABLE IF EXISTS `config_category`",
         }
         expected_downgrade_operators = {
             "ALTER TABLE `category` MODIFY COLUMN `name` VARCHAR(200) NOT NULL",
@@ -942,6 +985,8 @@ def test_migrate(mocker: MockerFixture):
             "ALTER TABLE `user` MODIFY COLUMN `longitude` DECIMAL(12,9) NOT NULL",
             "ALTER TABLE `product` MODIFY COLUMN `body` LONGTEXT NOT NULL",
             "ALTER TABLE `email` MODIFY COLUMN `is_primary` BOOL NOT NULL  DEFAULT 0",
+            "CREATE TABLE `config_category` (\n    `config_id` INT NOT NULL REFERENCES `config` (`id`) ON DELETE CASCADE,\n    `category_id` INT NOT NULL REFERENCES `category` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "DROP TABLE IF EXISTS `config_category_map`",
         }
         if should_add_user_id_column_type_alter_sql():
             sql = "ALTER TABLE `category` MODIFY COLUMN `user_id` INT NOT NULL  COMMENT 'User'"
@@ -991,6 +1036,8 @@ def test_migrate(mocker: MockerFixture):
             'CREATE UNIQUE INDEX "uid_product_name_869427" ON "product" ("name", "type_db_alias")',
             'CREATE UNIQUE INDEX "uid_user_usernam_9987ab" ON "user" ("username")',
             'CREATE TABLE "product_user" (\n    "product_id" INT NOT NULL REFERENCES "product" ("id") ON DELETE CASCADE,\n    "user_id" INT NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE\n)',
+            'CREATE TABLE "config_category_map" (\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE,\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE\n)',
+            'DROP TABLE IF EXISTS "config_category"',
         }
         expected_downgrade_operators = {
             'CREATE UNIQUE INDEX "uid_category_title_f7fc03" ON "category" ("title")',
@@ -1029,6 +1076,7 @@ def test_migrate(mocker: MockerFixture):
             'DROP INDEX "uid_product_name_869427"',
             'DROP TABLE IF EXISTS "email_user"',
             'DROP TABLE IF EXISTS "newmodel"',
+            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)', 'DROP TABLE IF EXISTS "config_category_map"'
         }
         if should_add_user_id_column_type_alter_sql():
             sql = 'ALTER TABLE "category" ALTER COLUMN "user_id" TYPE INT USING "user_id"::INT'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,10 +16,9 @@ class TestReorderM2M:
             {"name": "members", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new
 
     def test_same_through_with_different_orders(self) -> None:
         old = [
@@ -30,10 +29,9 @@ class TestReorderM2M:
             {"name": "admins", "through": "admins_group"},
             {"name": "members", "through": "users_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
 
     def test_the_same_field_name_order(self) -> None:
         old = [
@@ -44,10 +42,9 @@ class TestReorderM2M:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new
 
     def test_same_field_name_with_different_orders(self) -> None:
         old = [
@@ -58,10 +55,9 @@ class TestReorderM2M:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
 
     def test_drop_one(self) -> None:
         old = [
@@ -71,11 +67,10 @@ class TestReorderM2M:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert new == new_backup
-        assert old == old_backup[::-1]
-        assert old[0] == new[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old[::-1]
+        assert sorted_new == new
+        assert sorted_old[0] == new[0]
 
     def test_add_one(self) -> None:
         old = [
@@ -85,11 +80,10 @@ class TestReorderM2M:
             {"name": "users", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
-        assert new[0] == old[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
+        assert sorted_old[0] == sorted_new[0]
 
     def test_drop_some(self) -> None:
         old = [
@@ -100,10 +94,9 @@ class TestReorderM2M:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert new == new_backup
-        assert old[0] == old_backup[1] == new[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_new == new
+        assert sorted_old[0] == old[1] == sorted_new[0]
 
     def test_add_some(self) -> None:
         old = [
@@ -114,7 +107,35 @@ class TestReorderM2M:
             {"name": "admins", "through": "admins_group"},
             {"name": "staffs", "through": "staffs_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new[0] == new_backup[-1] == old[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new[0] == new[-1] == sorted_old[0]
+
+    def test_some_through_unchanged(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins_new", "through": "admins_group"},
+            {"name": "staffs_new", "through": "staffs_group"},
+        ]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert [i["through"] for i in sorted_new][: len(old)] == [i["through"] for i in sorted_old]
+
+    def test_some_unchanged_without_drop_or_add(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "users", "through": "users_group"},
+        ]
+        new = [
+            {"name": "users_new", "through": "users_group"},
+            {"name": "admins_new", "through": "admins_group"},
+            {"name": "staffs_new", "through": "staffs_group"},
+        ]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert [i["through"] for i in sorted_new] == [i["through"] for i in sorted_old]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,120 @@
-from aerich.utils import import_py_file
+from aerich.utils import import_py_file, reorder_m2m_fields
 
 
 def test_import_py_file() -> None:
     m = import_py_file("aerich/utils.py")
     assert getattr(m, "import_py_file", None)
+
+
+class TestReorderM2M:
+    def test_the_same_through_order(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "members", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup
+
+    def test_same_through_with_different_orders(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+            {"name": "members", "through": "users_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+
+    def test_the_same_field_name_order(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "user_groups"},
+            {"name": "admins", "through": "admin_groups"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup
+
+    def test_same_field_name_with_different_orders(self) -> None:
+        old = [
+            {"name": "admins", "through": "admins_group"},
+            {"name": "users", "through": "users_group"},
+        ]
+        new = [
+            {"name": "users", "through": "user_groups"},
+            {"name": "admins", "through": "admin_groups"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+
+    def test_drop_one(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert new == new_backup
+        assert old == old_backup[::-1]
+        assert old[0] == new[0]
+
+    def test_add_one(self) -> None:
+        old = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+        assert new[0] == old[0]
+
+    def test_drop_some(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert new == new_backup
+        assert old[0] == old_backup[1] == new[0]
+
+    def test_add_some(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new[0] == new_backup[-1] == old[0]


### PR DESCRIPTION
Fixes #375 
Fixes #150 

## Description
The two bugs are some thing like the following case:
```py
old = [{'through': 'a'}, {'through': 'b'}, {'through': 'c'}]
new = [{'through': 'a'}, {'through': 'c'}]
print(list(dictdiffer.diff(old, new)))
```
Got:
```
[('change', [1, 'through'], ('b', 'c')),
 ('remove', '', [(2, {'through': 'c'})])]
```
Expected:
```
[('remove', '', [(1, {'through': 'b'})])]
```
### Reason
When use `dictdiffer.diff` to compare two lists of dicts, it just compare elements at the same position:
```
old[0] vs new[0]
old[1] vs new[1]
```
### Solution
- [ ] 1. use a custom diff function that generate the expected output:
```py
def diff(old: dict, new: dict, key: str) -> list[tuple]:
      # compare dicts that with same key instead of compare dicts with same index
```
- [x] 2. reorder the list elements: in this case switch old[1] and old[2] will get the expected output