### PR TITLE
fix: NonExistentKey when running `aerich init` without `[tool]` section in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.1](Unreleased)
 
 #### Fixed
+- Fix NonExistentKey when running `aerich init` without `[tool]` section in config file. (#284)
 - Fix configuration file reading error when containing Chinese characters. (#286)
 - sqlite: failed to create/drop index. (#302)
 - PostgreSQL: Cannot drop constraint after deleting or rename FK on a model. (#378)

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -190,7 +190,10 @@ async def init(ctx: Context, tortoise_orm, location, src_folder) -> None:
     table["tortoise_orm"] = tortoise_orm
     table["location"] = location
     table["src_folder"] = src_folder
-    doc["tool"]["aerich"] = table
+    try:
+        doc["tool"]["aerich"] = table
+    except KeyError:
+        doc["tool"] = {"aerich": table}
 
     config_path.write_text(tomlkit.dumps(doc))
 

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -230,3 +230,9 @@ def test_sqlite_migrate(tmp_path: Path) -> None:
                 p.unlink()
         run_aerich("aerich init-db")
         assert db_file.exists()
+
+        # init without '[tool]' section in pyproject.toml
+        config_file = Path("pyproject.toml")
+        config_file.write_text('[project]\nname = "project"')
+        run_aerich("init -t settings.TORTOISE_ORM")
+        assert "[tool.aerich]" in config_file.read_text()


### PR DESCRIPTION
Fixes #284 