### PR TITLE
fix: setting null=false on m2m field causes migration to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.1](Unreleased)
 
 #### Fixed
+- Setting null=false on m2m field causes migration to fail. (#334)
 - Fix NonExistentKey when running `aerich init` without `[tool]` section in config file. (#284)
 - Fix configuration file reading error when containing Chinese characters. (#286)
 - sqlite: failed to create/drop index. (#302)

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -275,8 +275,8 @@ class Migrate:
                     length = len(old_m2m_fields)
                     field_index = {f["name"]: i for i, f in enumerate(new_m2m_fields)}
                     new_m2m_fields.sort(key=lambda field: field_index.get(field["name"], length))
-                for action, _, change in diff(old_m2m_fields, new_m2m_fields):
-                    if change[0][0] == "db_constraint":
+                for action, option, change in diff(old_m2m_fields, new_m2m_fields):
+                    if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
                         continue
                     new_value = change[0][1]
                     if isinstance(new_value, str):

--- a/tests/models.py
+++ b/tests/models.py
@@ -57,7 +57,9 @@ class Category(Model):
 
 
 class Product(Model):
-    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField("models.Category")
+    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField(
+        "models.Category", null=False
+    )
     users: fields.ManyToManyRelation[User] = fields.ManyToManyField(
         "models.User", related_name="products"
     )


### PR DESCRIPTION
Fixes #334 

Nullable constraint of m2m field is not controlled by db, so ignore it when migrate.