### PR TITLE
fix: migrate drop the wrong m2m field when model have multi m2m fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.1](Unreleased)
 
 #### Fixed
+- Migrate drop the wrong m2m field when model have multi m2m fields. (#376)
 - Sort m2m fields before comparing them with diff. (#271)
 
 ### [0.8.0](../../releases/tag/v0.8.0) - 2024-12-04

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -13,7 +13,12 @@ from tortoise.indexes import Index
 
 from aerich.ddl import BaseDDL
 from aerich.models import MAX_VERSION_LENGTH, Aerich
-from aerich.utils import diff_fields, get_app_connection, get_models_describe, is_default_function
+from aerich.utils import (
+    get_app_connection,
+    get_dict_diff_by_key,
+    get_models_describe,
+    is_default_function,
+)
 
 MIGRATE_TEMPLATE = """from tortoise import BaseDBAsyncClient
 
@@ -229,7 +234,7 @@ class Migrate:
     ) -> None:
         old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
         new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
-        for action, option, change in diff_fields(old_m2m_fields, new_m2m_fields):
+        for action, option, change in get_dict_diff_by_key(old_m2m_fields, new_m2m_fields):
             if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
                 continue
             new_value = change[0][1]

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -13,7 +13,12 @@ from tortoise.indexes import Index
 
 from aerich.ddl import BaseDDL
 from aerich.models import MAX_VERSION_LENGTH, Aerich
-from aerich.utils import get_app_connection, get_models_describe, is_default_function
+from aerich.utils import (
+    get_app_connection,
+    get_models_describe,
+    is_default_function,
+    reorder_m2m_fields,
+)
 
 MIGRATE_TEMPLATE = """from tortoise import BaseDBAsyncClient
 
@@ -271,10 +276,8 @@ class Migrate:
                 # m2m fields
                 old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
                 new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
-                if old_m2m_fields and len(new_m2m_fields) >= 2:
-                    length = len(old_m2m_fields)
-                    field_index = {f["name"]: i for i, f in enumerate(new_m2m_fields)}
-                    new_m2m_fields.sort(key=lambda field: field_index.get(field["name"], length))
+                if old_m2m_fields and new_m2m_fields:
+                    reorder_m2m_fields(old_m2m_fields, new_m2m_fields)
                 for action, _, change in diff(old_m2m_fields, new_m2m_fields):
                     if change[0][0] == "db_constraint":
                         continue

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -13,12 +13,7 @@ from tortoise.indexes import Index
 
 from aerich.ddl import BaseDDL
 from aerich.models import MAX_VERSION_LENGTH, Aerich
-from aerich.utils import (
-    get_app_connection,
-    get_models_describe,
-    is_default_function,
-    reorder_m2m_fields,
-)
+from aerich.utils import diff_fields, get_app_connection, get_models_describe, is_default_function
 
 MIGRATE_TEMPLATE = """from tortoise import BaseDBAsyncClient
 
@@ -229,6 +224,49 @@ class Migrate:
         return indexes
 
     @classmethod
+    def _handle_m2m_fields(
+        cls, old_model_describe: Dict, new_model_describe: Dict, model, new_models, upgrade=True
+    ) -> None:
+        old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
+        new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
+        for action, option, change in diff_fields(old_m2m_fields, new_m2m_fields):
+            if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
+                continue
+            new_value = change[0][1]
+            if isinstance(new_value, str):
+                for new_m2m_field in new_m2m_fields:
+                    if new_m2m_field["name"] == new_value:
+                        table = cast(str, new_m2m_field.get("through"))
+                        break
+            else:
+                table = new_value.get("through")
+            if action == "add":
+                add = False
+                if upgrade and table not in cls._upgrade_m2m:
+                    cls._upgrade_m2m.append(table)
+                    add = True
+                elif not upgrade and table not in cls._downgrade_m2m:
+                    cls._downgrade_m2m.append(table)
+                    add = True
+                if add:
+                    ref_desc = cast(dict, new_models.get(new_value.get("model_name")))
+                    cls._add_operator(
+                        cls.create_m2m(model, new_value, ref_desc),
+                        upgrade,
+                        fk_m2m_index=True,
+                    )
+            elif action == "remove":
+                add = False
+                if upgrade and table not in cls._upgrade_m2m:
+                    cls._upgrade_m2m.append(table)
+                    add = True
+                elif not upgrade and table not in cls._downgrade_m2m:
+                    cls._downgrade_m2m.append(table)
+                    add = True
+                if add:
+                    cls._add_operator(cls.drop_m2m(table), upgrade, True)
+
+    @classmethod
     def diff_models(
         cls, old_models: Dict[str, dict], new_models: Dict[str, dict], upgrade=True
     ) -> None:
@@ -282,48 +320,9 @@ class Migrate:
                     if action == "change" and option == "name":
                         cls._add_operator(cls._rename_field(model, *change), upgrade)
                 # m2m fields
-                old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
-                new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
-                if old_m2m_fields and new_m2m_fields:
-                    old_m2m_fields, new_m2m_fields = reorder_m2m_fields(
-                        old_m2m_fields, new_m2m_fields
-                    )
-                for action, option, change in diff(old_m2m_fields, new_m2m_fields):
-                    if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
-                        continue
-                    new_value = change[0][1]
-                    if isinstance(new_value, str):
-                        for new_m2m_field in new_m2m_fields:
-                            if new_m2m_field["name"] == new_value:
-                                table = cast(str, new_m2m_field.get("through"))
-                                break
-                    else:
-                        table = new_value.get("through")
-                    if action == "add":
-                        add = False
-                        if upgrade and table not in cls._upgrade_m2m:
-                            cls._upgrade_m2m.append(table)
-                            add = True
-                        elif not upgrade and table not in cls._downgrade_m2m:
-                            cls._downgrade_m2m.append(table)
-                            add = True
-                        if add:
-                            ref_desc = cast(dict, new_models.get(new_value.get("model_name")))
-                            cls._add_operator(
-                                cls.create_m2m(model, new_value, ref_desc),
-                                upgrade,
-                                fk_m2m_index=True,
-                            )
-                    elif action == "remove":
-                        add = False
-                        if upgrade and table not in cls._upgrade_m2m:
-                            cls._upgrade_m2m.append(table)
-                            add = True
-                        elif not upgrade and table not in cls._downgrade_m2m:
-                            cls._downgrade_m2m.append(table)
-                            add = True
-                        if add:
-                            cls._add_operator(cls.drop_m2m(table), upgrade, True)
+                cls._handle_m2m_fields(
+                    old_model_describe, new_model_describe, model, new_models, upgrade
+                )
                 # add unique_together
                 for index in new_unique_together.difference(old_unique_together):
                     cls._add_operator(cls._add_index(model, index, True), upgrade, True)

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -277,7 +277,9 @@ class Migrate:
                 old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
                 new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
                 if old_m2m_fields and new_m2m_fields:
-                    reorder_m2m_fields(old_m2m_fields, new_m2m_fields)
+                    old_m2m_fields, new_m2m_fields = reorder_m2m_fields(
+                        old_m2m_fields, new_m2m_fields
+                    )
                 for action, _, change in diff(old_m2m_fields, new_m2m_fields):
                     if change[0][0] == "db_constraint":
                         continue

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -114,7 +114,7 @@ def diff_fields(
 
     :param old_fields: previous field info list
     :param new_fields: current field info list
-    :param ident_key: if two dicts have the same ident_key, option is change; otherwise, is remove/add
+    :param ident_key: if two dicts have the same ident_key, action is change; otherwise, is remove/add
     :return: similar to dictdiffer.diff
 
     Example::
@@ -122,7 +122,8 @@ def diff_fields(
         >>> old = [{'through': 'a'}, {'through': 'b'}, {'through': 'c'}]
         >>> new = [{'through': 'a'}, {'through': 'c'}]  # remove the second element
         >>> list(diff(old, new))
-        [('change', [1, 'through'], ('b', 'c')), ('remove', '', [(2, {'through': 'c'})])]
+        [('change', [1, 'through'], ('b', 'c')),
+         ('remove', '', [(2, {'through': 'c'})])]
         >>> list(diff_fields(old, new))
         [('remove', '', [(0, {'through': 'b'})])]
 

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -110,11 +110,11 @@ def get_dict_diff_by_key(
     old_fields: list[dict], new_fields: list[dict], key="through"
 ) -> Generator[tuple]:
     """
-    Compare two list by ident_key instead of by index
+    Compare two list by key instead of by index
 
     :param old_fields: previous field info list
     :param new_fields: current field info list
-    :param ident_key: if two dicts have the same ident_key, action is change; otherwise, is remove/add
+    :param key: if two dicts have the same value of this key, action is change; otherwise, is remove/add
     :return: similar to dictdiffer.diff
 
     Example::

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -6,9 +6,10 @@ import re
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, Optional, Union
+from typing import Dict, Generator, Optional, Union
 
 from asyncclick import BadOptionUsage, ClickException, Context
+from dictdiffer import diff
 from tortoise import BaseDBAsyncClient, Tortoise
 
 
@@ -105,110 +106,40 @@ def import_py_file(file: Union[str, Path]) -> ModuleType:
     return module
 
 
-def _pick_match_to_head(m2m_fields: list[dict], field_info: dict) -> list[dict]:
+def diff_fields(
+    old_fields: list[dict], new_fields: list[dict], ident_key="through"
+) -> Generator[tuple]:
     """
-    If there is a element in m2m_fields whose through or name is equal to field_info's
-    and this element is not at the first position, put it to the head then return the
-    new list, otherwise return the origin list.
+    Compare two list by ident_key instead of by index
+
+    :param old_fields: previous field info list
+    :param new_fields: current field info list
+    :param ident_key: if two dicts have the same ident_key, option is change; otherwise, is remove/add
+    :return: similar to dictdiffer.diff
 
     Example::
-        >>> m2m_fields = [{'through': 'u1', 'name': 'u1'}, {'throught': 'u2', 'name': 'u2'}]
-        >>> _pick_match_to_head(m2m_fields, {'through': 'u2', 'name': 'u2'})
-        [{'through': 'u2', 'name': 'u2'}, {'through': 'u1', 'name': 'u1'}]
+
+        >>> old = [{'through': 'a'}, {'through': 'b'}, {'through': 'c'}]
+        >>> new = [{'through': 'a'}, {'through': 'c'}]  # remove the second element
+        >>> list(diff(old, new))
+        [('change', [1, 'through'], ('b', 'c')), ('remove', '', [(2, {'through': 'c'})])]
+        >>> list(diff_fields(old, new))
+        [('remove', '', [(0, {'through': 'b'})])]
 
     """
-    through = field_info["through"]
-    name = field_info["name"]
-    for index, field in enumerate(m2m_fields):
-        if field["through"] == through or field["name"] == name:
-            if index != 0:
-                m2m_fields = [field, *m2m_fields[:index], *m2m_fields[index + 1 :]]
-            break
-    return m2m_fields
-
-
-def reorder_m2m_fields(
-    old_m2m_fields: list[dict], new_m2m_fields: list[dict]
-) -> tuple[list[dict], list[dict]]:
-    """
-    Reorder m2m fields to help dictdiffer.diff generate more precise changes
-    :param old_m2m_fields: previous m2m field info list
-    :param new_m2m_fields: current m2m field info list
-    :return: ordered old/new m2m fields
-    """
-    length_old, length_new = len(old_m2m_fields), len(new_m2m_fields)
-    if length_old == length_new == 1:
-        # No need to change order if both of them have only one element
-        pass
-    elif length_old == 1:
-        # If any element of new fields match the one in old fields, put it to head
-        new_m2m_fields = _pick_match_to_head(new_m2m_fields, old_m2m_fields[0])
-    elif length_new == 1:
-        old_m2m_fields = _pick_match_to_head(old_m2m_fields, new_m2m_fields[0])
+    length_old, length_new = len(old_fields), len(new_fields)
+    if length_old == 0 or length_new == 0 or length_old == length_new == 1:
+        yield from diff(old_fields, new_fields)
     else:
-        old_table_names = [f["through"] for f in old_m2m_fields]
-        new_table_names = [f["through"] for f in new_m2m_fields]
-        old_field_names = [f["name"] for f in old_m2m_fields]
-        new_field_names = [f["name"] for f in new_m2m_fields]
-        if old_table_names == new_table_names:
-            pass
-        elif sorted(old_table_names) == sorted(new_table_names):
-            # If table name are the same but order not match,
-            # reorder new fields by through to match the order of old.
-
-            # Case like::
-            # old_m2m_fields = [
-            #     {'through': 'users_group', 'name': 'users',},
-            #     {'through': 'admins_group', 'name': 'admins'},
-            # ]
-            # new_m2m_fields = [
-            #     {'through': 'admins_group', 'name': 'admins_new'},
-            #     {'through': 'users_group', 'name': 'users_new',},
-            # ]
-            new_m2m_fields = sorted(
-                new_m2m_fields, key=lambda f: old_table_names.index(f["through"])
-            )
-        elif old_field_names == new_field_names:
-            pass
-        elif sorted(old_field_names) == sorted(new_field_names):
-            # Case like:
-            # old_m2m_fields = [
-            #     {'name': 'users', 'through': 'users_group'},
-            #     {'name': 'admins', 'through': 'admins_group'},
-            # ]
-            # new_m2m_fields = [
-            #     {'name': 'admins', 'through': 'admin_group_map'},
-            #     {'name': 'users', 'through': 'user_group_map'},
-            # ]
-            new_m2m_fields = sorted(new_m2m_fields, key=lambda f: old_field_names.index(f["name"]))
-        elif unchanged_table_names := set(old_table_names) & set(new_table_names):
-            # If old/new m2m field list have one or some unchanged table names, put them to head of list.
-
-            # Case like::
-            # old_m2m_fields = [
-            #     {'through': 'users_group', 'name': 'users',},
-            #     {'through': 'staffs_group', 'name': 'users',},
-            #     {'through': 'admins_group', 'name': 'admins'},
-            # ]
-            # new_m2m_fields = [
-            #     {'through': 'admins_group', 'name': 'admins_new'},
-            #     {'through': 'users_group', 'name': 'users_new',},
-            # ]
-            unchanged = sorted(unchanged_table_names, key=lambda name: old_table_names.index(name))
-            ordered_old_tables = unchanged + sorted(
-                set(old_table_names) - unchanged_table_names,
-                key=lambda name: old_table_names.index(name),
-            )
-            ordered_new_tables = unchanged + sorted(
-                set(new_table_names) - unchanged_table_names,
-                key=lambda name: new_table_names.index(name),
-            )
-            if ordered_old_tables != old_table_names:
-                old_m2m_fields = sorted(
-                    old_m2m_fields, key=lambda f: ordered_old_tables.index(f["through"])
-                )
-            if ordered_new_tables != new_table_names:
-                new_m2m_fields = sorted(
-                    new_m2m_fields, key=lambda f: ordered_new_tables.index(f["through"])
-                )
-    return old_m2m_fields, new_m2m_fields
+        new_throughs = {f["through"]: i for i, f in enumerate(new_fields)}
+        additions = set(range(length_new))
+        for field in old_fields:
+            through = field["through"]
+            if (index := new_throughs.get(through)) is not None:
+                additions.remove(index)
+                yield from diff([field], [new_fields[index]])  # change
+            else:
+                yield from diff([field], [])  # remove
+        if additions:
+            for index in sorted(additions):
+                yield from diff([], [new_fields[index]])  # add

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -105,32 +105,110 @@ def import_py_file(file: Union[str, Path]) -> ModuleType:
     return module
 
 
-def reorder_m2m_fields(old_m2m_fields: list[dict], new_m2m_fields: list[dict]) -> None:
+def _pick_match_to_head(m2m_fields: list[dict], field_info: dict) -> list[dict]:
+    """
+    If there is a element in m2m_fields whose through or name is equal to field_info's
+    and this element is not at the first position, put it to the head then return the
+    new list, otherwise return the origin list.
+
+    Example::
+        >>> m2m_fields = [{'through': 'u1', 'name': 'u1'}, {'throught': 'u2', 'name': 'u2'}]
+        >>> _pick_match_to_head(m2m_fields, {'through': 'u2', 'name': 'u2'})
+        [{'through': 'u2', 'name': 'u2'}, {'throught': 'u1', 'name': 'u1'}]
+
+    """
+    through = field_info["through"]
+    name = field_info["name"]
+    for index, field in enumerate(m2m_fields):
+        if field["through"] == through or field["name"] == name:
+            if index != 0:
+                m2m_fields = [field, *m2m_fields[:index], *m2m_fields[index + 1 :]]
+            break
+    return m2m_fields
+
+
+def reorder_m2m_fields(
+    old_m2m_fields: list[dict], new_m2m_fields: list[dict]
+) -> tuple[list[dict], list[dict]]:
     """
     Reorder m2m fields to help dictdiffer.diff generate more precise changes
     :param old_m2m_fields: previous m2m field info list
     :param new_m2m_fields: current m2m field info list
-    :return:
+    :return: ordered old/new m2m fields
     """
-    old_table_names: list[str] = [f["through"] for f in old_m2m_fields]
-    new_table_names: list[str] = [f["through"] for f in new_m2m_fields]
-    if old_table_names == new_table_names:
-        return
-    if sorted(old_table_names) == sorted(new_table_names):
-        new_m2m_fields.sort(key=lambda field: old_table_names.index(field["through"]))
-        return
-    old_field_names: list[str] = [f["name"] for f in old_m2m_fields]
-    new_field_names: list[str] = [f["name"] for f in new_m2m_fields]
-    if old_field_names == new_field_names:
-        return
-    if sorted(old_field_names) == sorted(new_field_names):
-        new_m2m_fields.sort(key=lambda field: old_field_names.index(field["name"]))
-        return
-    if unchanged_tables := set(old_table_names) & set(new_table_names):
-        unchanged = sorted(unchanged_tables)
-        ordered_old_tables = unchanged + sorted(set(old_table_names) - unchanged_tables)
-        ordered_new_tables = unchanged + sorted(set(new_table_names) - unchanged_tables)
-        if ordered_old_tables != old_table_names:
-            old_m2m_fields.sort(key=lambda field: ordered_old_tables.index(field["through"]))
-        if ordered_new_tables != new_table_names:
-            new_m2m_fields.sort(key=lambda field: ordered_new_tables.index(field["through"]))
+    length_old, length_new = len(old_m2m_fields), len(new_m2m_fields)
+    if length_old == length_new == 1:
+        # No need to change order if both of them have only one element
+        pass
+    elif length_old == 1:
+        # If any element of new fields match the one in old fields, put it to head
+        new_m2m_fields = _pick_match_to_head(new_m2m_fields, old_m2m_fields[0])
+    elif length_new == 1:
+        old_m2m_fields = _pick_match_to_head(old_m2m_fields, new_m2m_fields[0])
+    else:
+        old_table_names = [f["through"] for f in old_m2m_fields]
+        new_table_names = [f["through"] for f in new_m2m_fields]
+        old_field_names = [f["name"] for f in old_m2m_fields]
+        new_field_names = [f["name"] for f in new_m2m_fields]
+        if old_table_names == new_table_names:
+            pass
+        elif sorted(old_table_names) == sorted(new_table_names):
+            # If table name are the same but order not match,
+            # reorder new fields by through to match the order of old.
+
+            # Case like::
+            # old_m2m_fields = [
+            #     {'through': 'users_group', 'name': 'users',},
+            #     {'through': 'admins_group', 'name': 'admins'},
+            # ]
+            # new_m2m_fields = [
+            #     {'through': 'admins_group', 'name': 'admins_new'},
+            #     {'through': 'users_group', 'name': 'users_new',},
+            # ]
+            new_m2m_fields = sorted(
+                new_m2m_fields, key=lambda f: old_table_names.index(f["through"])
+            )
+        elif old_field_names == new_field_names:
+            pass
+        elif sorted(old_field_names) == sorted(new_field_names):
+            # Case like:
+            # old_m2m_fields = [
+            #     {'name': 'users', 'through': 'users_group'},
+            #     {'name': 'admins', 'through': 'admins_group'},
+            # ]
+            # new_m2m_fields = [
+            #     {'name': 'admins', 'through': 'admin_group_map'},
+            #     {'name': 'users', 'through': 'user_group_map'},
+            # ]
+            new_m2m_fields = sorted(new_m2m_fields, key=lambda f: old_field_names.index(f["name"]))
+        elif unchanged_table_names := set(old_table_names) & set(new_table_names):
+            # If old/new m2m field list have one or some unchanged table names, put them to head of list.
+
+            # Case like::
+            # old_m2m_fields = [
+            #     {'through': 'users_group', 'name': 'users',},
+            #     {'through': 'staffs_group', 'name': 'users',},
+            #     {'through': 'admins_group', 'name': 'admins'},
+            # ]
+            # new_m2m_fields = [
+            #     {'through': 'admins_group', 'name': 'admins_new'},
+            #     {'through': 'users_group', 'name': 'users_new',},
+            # ]
+            unchanged = sorted(unchanged_table_names, key=lambda name: old_table_names.index(name))
+            ordered_old_tables = unchanged + sorted(
+                set(old_table_names) - unchanged_table_names,
+                key=lambda name: old_table_names.index(name),
+            )
+            ordered_new_tables = unchanged + sorted(
+                set(new_table_names) - unchanged_table_names,
+                key=lambda name: new_table_names.index(name),
+            )
+            if ordered_old_tables != old_table_names:
+                old_m2m_fields = sorted(
+                    old_m2m_fields, key=lambda f: ordered_old_tables.index(f["through"])
+                )
+            if ordered_new_tables != new_table_names:
+                new_m2m_fields = sorted(
+                    new_m2m_fields, key=lambda f: ordered_new_tables.index(f["through"])
+                )
+    return old_m2m_fields, new_m2m_fields

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -106,8 +106,8 @@ def import_py_file(file: Union[str, Path]) -> ModuleType:
     return module
 
 
-def diff_fields(
-    old_fields: list[dict], new_fields: list[dict], ident_key="through"
+def get_dict_diff_by_key(
+    old_fields: list[dict], new_fields: list[dict], key="through"
 ) -> Generator[tuple]:
     """
     Compare two list by ident_key instead of by index
@@ -124,7 +124,7 @@ def diff_fields(
         >>> list(diff(old, new))
         [('change', [1, 'through'], ('b', 'c')),
          ('remove', '', [(2, {'through': 'c'})])]
-        >>> list(diff_fields(old, new))
+        >>> list(get_dict_diff_by_key(old, new))
         [('remove', '', [(0, {'through': 'b'})])]
 
     """
@@ -132,11 +132,11 @@ def diff_fields(
     if length_old == 0 or length_new == 0 or length_old == length_new == 1:
         yield from diff(old_fields, new_fields)
     else:
-        new_throughs = {f["through"]: i for i, f in enumerate(new_fields)}
+        value_index: dict[str, int] = {f[key]: i for i, f in enumerate(new_fields)}
         additions = set(range(length_new))
         for field in old_fields:
-            through = field["through"]
-            if (index := new_throughs.get(through)) is not None:
+            value = field[key]
+            if (index := value_index.get(value)) is not None:
                 additions.remove(index)
                 yield from diff([field], [new_fields[index]])  # change
             else:

--- a/tests/models.py
+++ b/tests/models.py
@@ -78,6 +78,9 @@ class Product(Model):
 
 
 class Config(Model):
+    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField(
+        "models.Category", through="config_category_map", related_name="category_set"
+    )
     label = fields.CharField(max_length=200)
     key = fields.CharField(max_length=20)
     value: dict = fields.JSONField()

--- a/tests/old_models.py
+++ b/tests/old_models.py
@@ -65,6 +65,10 @@ class Product(Model):
 
 
 class Config(Model):
+    category: fields.ManyToManyRelation[Category] = fields.ManyToManyField("models.Category")
+    categories: fields.ManyToManyRelation[Category] = fields.ManyToManyField(
+        "models.Category", through="config_category_map", related_name="config_set"
+    )
     name = fields.CharField(max_length=100, unique=True)
     label = fields.CharField(max_length=200)
     key = fields.CharField(max_length=20)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1076,7 +1076,8 @@ def test_migrate(mocker: MockerFixture):
             'DROP INDEX "uid_product_name_869427"',
             'DROP TABLE IF EXISTS "email_user"',
             'DROP TABLE IF EXISTS "newmodel"',
-            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)', 'DROP TABLE IF EXISTS "config_category_map"'
+            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)',
+            'DROP TABLE IF EXISTS "config_category_map"',
         }
         if should_add_user_id_column_type_alter_sql():
             sql = 'ALTER TABLE "category" ALTER COLUMN "user_id" TYPE INT USING "user_id"::INT'

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -268,7 +268,48 @@ old_models_describe = {
         "backward_fk_fields": [],
         "o2o_fields": [],
         "backward_o2o_fields": [],
-        "m2m_fields": [],
+        "m2m_fields": [
+            {
+                "name": "category",
+                "field_type": "ManyToManyFieldInstance",
+                "python_type": "models.Category",
+                "generated": False,
+                "nullable": False,
+                "unique": False,
+                "indexed": False,
+                "default": None,
+                "description": None,
+                "docstring": None,
+                "constraints": {},
+                "model_name": "models.Category",
+                "related_name": "configs",
+                "forward_key": "category_id",
+                "backward_key": "config_id",
+                "through": "config_category",
+                "on_delete": "CASCADE",
+                "_generated": False,
+            },
+            {
+                "name": "categories",
+                "field_type": "ManyToManyFieldInstance",
+                "python_type": "models.Category",
+                "generated": False,
+                "nullable": False,
+                "unique": False,
+                "indexed": False,
+                "default": None,
+                "description": None,
+                "docstring": None,
+                "constraints": {},
+                "model_name": "models.Category",
+                "related_name": "config_set",
+                "forward_key": "category_id",
+                "backward_key": "config_id",
+                "through": "config_category_map",
+                "on_delete": "CASCADE",
+                "_generated": False,
+            },
+        ],
     },
     "models.Email": {
         "name": "models.Email",
@@ -904,6 +945,8 @@ def test_migrate(mocker: MockerFixture):
             "ALTER TABLE `product` MODIFY COLUMN `body` LONGTEXT NOT NULL",
             "ALTER TABLE `email` MODIFY COLUMN `is_primary` BOOL NOT NULL  DEFAULT 0",
             "CREATE TABLE `product_user` (\n    `product_id` INT NOT NULL REFERENCES `product` (`id`) ON DELETE CASCADE,\n    `user_id` INT NOT NULL REFERENCES `user` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "CREATE TABLE `config_category_map` (\n    `category_id` INT NOT NULL REFERENCES `category` (`id`) ON DELETE CASCADE,\n    `config_id` INT NOT NULL REFERENCES `config` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "DROP TABLE IF EXISTS `config_category`",
         }
         expected_downgrade_operators = {
             "ALTER TABLE `category` MODIFY COLUMN `name` VARCHAR(200) NOT NULL",
@@ -942,6 +985,8 @@ def test_migrate(mocker: MockerFixture):
             "ALTER TABLE `user` MODIFY COLUMN `longitude` DECIMAL(12,9) NOT NULL",
             "ALTER TABLE `product` MODIFY COLUMN `body` LONGTEXT NOT NULL",
             "ALTER TABLE `email` MODIFY COLUMN `is_primary` BOOL NOT NULL  DEFAULT 0",
+            "CREATE TABLE `config_category` (\n    `config_id` INT NOT NULL REFERENCES `config` (`id`) ON DELETE CASCADE,\n    `category_id` INT NOT NULL REFERENCES `category` (`id`) ON DELETE CASCADE\n) CHARACTER SET utf8mb4",
+            "DROP TABLE IF EXISTS `config_category_map`",
         }
         if should_add_user_id_column_type_alter_sql():
             sql = "ALTER TABLE `category` MODIFY COLUMN `user_id` INT NOT NULL  COMMENT 'User'"
@@ -991,6 +1036,8 @@ def test_migrate(mocker: MockerFixture):
             'CREATE UNIQUE INDEX "uid_product_name_869427" ON "product" ("name", "type_db_alias")',
             'CREATE UNIQUE INDEX "uid_user_usernam_9987ab" ON "user" ("username")',
             'CREATE TABLE "product_user" (\n    "product_id" INT NOT NULL REFERENCES "product" ("id") ON DELETE CASCADE,\n    "user_id" INT NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE\n)',
+            'CREATE TABLE "config_category_map" (\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE,\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE\n)',
+            'DROP TABLE IF EXISTS "config_category"',
         }
         expected_downgrade_operators = {
             'CREATE UNIQUE INDEX "uid_category_title_f7fc03" ON "category" ("title")',
@@ -1029,6 +1076,7 @@ def test_migrate(mocker: MockerFixture):
             'DROP INDEX "uid_product_name_869427"',
             'DROP TABLE IF EXISTS "email_user"',
             'DROP TABLE IF EXISTS "newmodel"',
+            'CREATE TABLE "config_category" (\n    "config_id" INT NOT NULL REFERENCES "config" ("id") ON DELETE CASCADE,\n    "category_id" INT NOT NULL REFERENCES "category" ("id") ON DELETE CASCADE\n)', 'DROP TABLE IF EXISTS "config_category_map"'
         }
         if should_add_user_id_column_type_alter_sql():
             sql = 'ALTER TABLE "category" ALTER COLUMN "user_id" TYPE INT USING "user_id"::INT'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from aerich.utils import diff_fields, import_py_file
+from aerich.utils import get_dict_diff_by_key, import_py_file
 
 
 def test_import_py_file() -> None:
@@ -16,8 +16,8 @@ class TestDiffFields:
             {"name": "members", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        diffs = list(diff_fields(old, new))
-        assert type(diff_fields(old, new)).__name__ == "generator"
+        diffs = list(get_dict_diff_by_key(old, new))
+        assert type(get_dict_diff_by_key(old, new)).__name__ == "generator"
         assert len(diffs) == 1
         assert diffs == [("change", [0, "name"], ("users", "members"))]
 
@@ -30,7 +30,7 @@ class TestDiffFields:
             {"name": "admins", "through": "admins_group"},
             {"name": "members", "through": "users_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 1
         assert diffs == [("change", [0, "name"], ("users", "members"))]
 
@@ -43,7 +43,7 @@ class TestDiffFields:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 4
         assert diffs == [
             ("remove", "", [(0, {"name": "users", "through": "users_group"})]),
@@ -61,7 +61,7 @@ class TestDiffFields:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 4
         assert diffs == [
             ("remove", "", [(0, {"name": "admins", "through": "admins_group"})]),
@@ -78,7 +78,7 @@ class TestDiffFields:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 1
         assert diffs == [("remove", "", [(0, {"name": "users", "through": "users_group"})])]
 
@@ -90,7 +90,7 @@ class TestDiffFields:
             {"name": "users", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 1
         assert diffs == [("add", "", [(0, {"name": "users", "through": "users_group"})])]
 
@@ -103,7 +103,7 @@ class TestDiffFields:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 2
         assert diffs == [
             ("remove", "", [(0, {"name": "users", "through": "users_group"})]),
@@ -119,7 +119,7 @@ class TestDiffFields:
             {"name": "admins", "through": "admins_group"},
             {"name": "staffs", "through": "staffs_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 2
         assert diffs == [
             ("add", "", [(0, {"name": "users", "through": "users_group"})]),
@@ -136,7 +136,7 @@ class TestDiffFields:
             {"name": "admins_new", "through": "admins_group"},
             {"name": "staffs_new", "through": "staffs_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 3
         assert diffs == [
             ("change", [0, "name"], ("staffs", "staffs_new")),
@@ -155,7 +155,7 @@ class TestDiffFields:
             {"name": "admins_new", "through": "admins_group"},
             {"name": "staffs_new", "through": "staffs_group"},
         ]
-        diffs = list(diff_fields(old, new))
+        diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 3
         assert diffs == [
             ("change", [0, "name"], ("staffs", "staffs_new")),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,10 +16,9 @@ class TestReorderM2M:
             {"name": "members", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new
 
     def test_same_through_with_different_orders(self) -> None:
         old = [
@@ -30,10 +29,9 @@ class TestReorderM2M:
             {"name": "admins", "through": "admins_group"},
             {"name": "members", "through": "users_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
 
     def test_the_same_field_name_order(self) -> None:
         old = [
@@ -44,10 +42,9 @@ class TestReorderM2M:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new
 
     def test_same_field_name_with_different_orders(self) -> None:
         old = [
@@ -58,10 +55,9 @@ class TestReorderM2M:
             {"name": "users", "through": "user_groups"},
             {"name": "admins", "through": "admin_groups"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
 
     def test_drop_one(self) -> None:
         old = [
@@ -71,11 +67,10 @@ class TestReorderM2M:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert new == new_backup
-        assert old == old_backup[::-1]
-        assert old[0] == new[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old[::-1]
+        assert sorted_new == new
+        assert sorted_old[0] == new[0]
 
     def test_add_one(self) -> None:
         old = [
@@ -85,11 +80,10 @@ class TestReorderM2M:
             {"name": "users", "through": "users_group"},
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new == new_backup[::-1]
-        assert new[0] == old[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new == new[::-1]
+        assert sorted_old[0] == sorted_new[0]
 
     def test_drop_some(self) -> None:
         old = [
@@ -100,10 +94,9 @@ class TestReorderM2M:
         new = [
             {"name": "admins", "through": "admins_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert new == new_backup
-        assert old[0] == old_backup[1] == new[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_new == new
+        assert sorted_old[0] == old[1] == sorted_new[0]
 
     def test_add_some(self) -> None:
         old = [
@@ -114,7 +107,35 @@ class TestReorderM2M:
             {"name": "admins", "through": "admins_group"},
             {"name": "staffs", "through": "staffs_group"},
         ]
-        old_backup, new_backup = old[:], new[:]
-        reorder_m2m_fields(old, new)
-        assert old == old_backup
-        assert new[0] == new_backup[-1] == old[0]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert sorted_new[0] == new[-1] == sorted_old[0]
+
+    def test_some_through_unchanged(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins_new", "through": "admins_group"},
+            {"name": "staffs_new", "through": "staffs_group"},
+        ]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert [i["through"] for i in sorted_new][: len(old)] == [i["through"] for i in sorted_old]
+
+    def test_some_unchanged_without_drop_or_add(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "users", "through": "users_group"},
+        ]
+        new = [
+            {"name": "users_new", "through": "users_group"},
+            {"name": "admins_new", "through": "admins_group"},
+            {"name": "staffs_new", "through": "staffs_group"},
+        ]
+        sorted_old, sorted_new = reorder_m2m_fields(old, new)
+        assert sorted_old == old
+        assert [i["through"] for i in sorted_new] == [i["through"] for i in sorted_old]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,120 @@
-from aerich.utils import import_py_file
+from aerich.utils import import_py_file, reorder_m2m_fields
 
 
 def test_import_py_file() -> None:
     m = import_py_file("aerich/utils.py")
     assert getattr(m, "import_py_file", None)
+
+
+class TestReorderM2M:
+    def test_the_same_through_order(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "members", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup
+
+    def test_same_through_with_different_orders(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+            {"name": "members", "through": "users_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+
+    def test_the_same_field_name_order(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "user_groups"},
+            {"name": "admins", "through": "admin_groups"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup
+
+    def test_same_field_name_with_different_orders(self) -> None:
+        old = [
+            {"name": "admins", "through": "admins_group"},
+            {"name": "users", "through": "users_group"},
+        ]
+        new = [
+            {"name": "users", "through": "user_groups"},
+            {"name": "admins", "through": "admin_groups"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+
+    def test_drop_one(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert new == new_backup
+        assert old == old_backup[::-1]
+        assert old[0] == new[0]
+
+    def test_add_one(self) -> None:
+        old = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new == new_backup[::-1]
+        assert new[0] == old[0]
+
+    def test_drop_some(self) -> None:
+        old = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        new = [
+            {"name": "admins", "through": "admins_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert new == new_backup
+        assert old[0] == old_backup[1] == new[0]
+
+    def test_add_some(self) -> None:
+        old = [
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        new = [
+            {"name": "users", "through": "users_group"},
+            {"name": "admins", "through": "admins_group"},
+            {"name": "staffs", "through": "staffs_group"},
+        ]
+        old_backup, new_backup = old[:], new[:]
+        reorder_m2m_fields(old, new)
+        assert old == old_backup
+        assert new[0] == new_backup[-1] == old[0]


### PR DESCRIPTION
Fixes #375 

## Description
The two bugs are some thing like the following case:
```py
old = [{'through': 'a'}, {'through': 'b'}, {'through': 'c'}]
new = [{'through': 'a'}, {'through': 'c'}]
print(list(dictdiffer.diff(old, new)))
```
Got:
```
[('change', [1, 'through'], ('b', 'c')),
 ('remove', '', [(2, {'through': 'c'})])]
```
Expected:
```
[('remove', '', [(1, {'through': 'b'})])]
```
### Reason
When use `dictdiffer.diff` to compare two lists of dicts, it just compare elements at the same position:
```
old[0] vs new[0]
old[1] vs new[1]
```
### Solution
- [x] 1. use a custom diff function that generate the expected output:
```py
def diff(old: dict, new: dict, key: str) -> Generator[tuple]:
    # compare dicts that with same key instead of compare dicts with same index
```
- [ ] 2. reorder the list elements: in this case switch old[1] and old[2] will get the expected output

----

- BTW: code of function `Migrate.diff_models` is really too long, so I move logic of m2m fields to a new classmethod.