### PR TITLE
fix: add m2m field with custom m2m through generate duplicated table when migrating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.1](Unreleased)
 
 #### Fixed
+- Migrate add m2m field with custom through generate duplicated table. (#393)
 - Migrate drop the wrong m2m field when model have multi m2m fields. (#376)
 - KeyError raised when removing or renaming an existing model (#386)
 - fix: error when there is `__init__.py` in the migration folder (#272)

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -234,6 +234,7 @@ class Migrate:
     ) -> None:
         old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
         new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
+        new_tables = {i["table"] for i in new_models.values()}
         for action, option, change in get_dict_diff_by_key(old_m2m_fields, new_m2m_fields):
             if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
                 continue
@@ -247,12 +248,14 @@ class Migrate:
                 table = new_value.get("through")
             if action == "add":
                 add = False
-                if upgrade and table not in cls._upgrade_m2m:
-                    cls._upgrade_m2m.append(table)
-                    add = True
-                elif not upgrade and table not in cls._downgrade_m2m:
-                    cls._downgrade_m2m.append(table)
-                    add = True
+                if upgrade:
+                    if table not in new_tables and table not in cls._upgrade_m2m:
+                        cls._upgrade_m2m.append(table)
+                        add = True
+                else:
+                    if table not in cls._downgrade_m2m:
+                        cls._downgrade_m2m.append(table)
+                        add = True
                 if add:
                     ref_desc = cast(dict, new_models.get(new_value.get("model_name")))
                     cls._add_operator(

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -228,13 +228,18 @@ class Migrate:
                 indexes.add(cast(Tuple[str, ...], tuple(x)))
         return indexes
 
+    @staticmethod
+    def _validate_custom_m2m_through(field: dict) -> None:
+        # TODO: Check whether field includes required fk columns
+        pass
+
     @classmethod
     def _handle_m2m_fields(
         cls, old_model_describe: Dict, new_model_describe: Dict, model, new_models, upgrade=True
     ) -> None:
         old_m2m_fields = cast(List[dict], old_model_describe.get("m2m_fields"))
         new_m2m_fields = cast(List[dict], new_model_describe.get("m2m_fields"))
-        new_tables = {i["table"] for i in new_models.values()}
+        new_tables: Dict[str, dict] = {field["table"]: field for field in new_models.values()}
         for action, option, change in get_dict_diff_by_key(old_m2m_fields, new_m2m_fields):
             if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
                 continue
@@ -249,7 +254,9 @@ class Migrate:
             if action == "add":
                 add = False
                 if upgrade:
-                    if table not in new_tables and table not in cls._upgrade_m2m:
+                    if field := new_tables.get(table):
+                        cls._validate_custom_m2m_through(field)
+                    elif table not in cls._upgrade_m2m:
                         cls._upgrade_m2m.append(table)
                         add = True
                 else:

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -130,6 +130,18 @@ async def test_without_age_field() -> None:
     await Foo.create(name=name, age=0)
     obj = await Foo.get(name=name)
     assert getattr(obj, "age", None) is None
+
+
+@pytest.mark.asyncio
+async def test_m2m_with_custom_through() -> None:
+    from models import Group, FooGroup
+    name = "4_" + uuid.uuid4().hex
+    foo = await Foo.create(name=name)
+    group = await Group.create(name=name+"1")
+    await FooGroup.all().delete()
+    await foo.groups.add(group)
+    foo_group = await FooGroup.get(foo=foo, group=group)
+    assert not foo_group.is_active
 """
 
 
@@ -247,7 +259,7 @@ class Group(Model):
 class FooGroup(Model):
     foo = fields.ForeignKeyField("models.Foo")
     group = fields.ForeignKeyField("models.Group")
-    is_active = fields.BooleanField()
+    is_active = fields.BooleanField(default=False)
 
     class Meta:
         table = "foo_group"
@@ -257,3 +269,5 @@ class FooGroup(Model):
         run_aerich("aerich upgrade")
         migration_file_1 = list(migrations_dir.glob("1_*.py"))[0]
         assert "foo_group" in migration_file_1.read_text()
+        r = run_shell("pytest _test.py::test_m2m_with_custom_through")
+        assert r.returncode == 0


### PR DESCRIPTION
Fixes #201

## Reason
If new models contain a table that have the same name with the m2m through, this table will create twice.

## Solution
Check that the m2m through is not in new models before add it add create list.