### PR TITLE
feat: support skip table migration by set `managed=False`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           - tortoise022
           - tortoise023
           - tortoise024
+          # TODO: add dev back when drop python3.8 support
+          # - tortoisedev
     steps:
       - name: Start MySQL
         run: sudo systemctl start mysql.service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Added
 - feat: support command `python -m aerich`. ([#417])
 - feat: add --fake to upgrade/downgrade. ([#398])
+- Support ignore table by settings `managed=False` in `Meta` class. ([#397])
 
 #### Fixed
 - fix: aerich migrate raises tortoise.exceptions.FieldError when `index.INDEX_TYPE` is not empty. ([#415])
@@ -17,6 +18,7 @@
 ### Changed
 - Refactored version management to use `importlib.metadata.version(__package__)` instead of hardcoded version string ([#412])
 
+[#397]: https://github.com/tortoise/aerich/pull/397
 [#398]: https://github.com/tortoise/aerich/pull/398
 [#401]: https://github.com/tortoise/aerich/pull/401
 [#404]: https://github.com/tortoise/aerich/pull/404

--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ aerich downgrade --fake -v 2
 aerich --app models downgrade --fake -v 2
 ```
 
+### Ignore tables
+
+You can tell aerich to ignore table by setting `managed=False` in the `Meta` class, e.g.:
+```py
+class MyModel(Model):
+    class Meta:
+        managed = False
+```
+**Note** `managed=False` does not recognized by `tortoise-orm` and `aerich init-db`, it is only for `aerich migrate`.
+
 ## License
 
 This project is licensed under the

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -34,15 +34,11 @@ def get_app_connection_name(config, app_name: str) -> str:
     get connection name
     :param config:
     :param app_name:
-    :return:
+    :return: the default connection name (Usally it is 'default')
     """
-    app = config.get("apps").get(app_name)
-    if not app:
-        raise BadOptionUsage(
-            option_name="--app",
-            message=f'Can\'t get app named "{app_name}"',
-        )
-    return app.get("default_connection", "default")
+    if app := config.get("apps").get(app_name):
+        return app.get("default_connection", "default")
+    raise BadOptionUsage(option_name="--app", message=f"Can't get app named {app_name!r}")
 
 
 def get_app_connection(config, app) -> BaseDBAsyncClient:
@@ -89,8 +85,9 @@ def get_models_describe(app: str) -> dict:
     """
     ret = {}
     for model in Tortoise.apps[app].values():
+        managed = getattr(model.Meta, "managed", None)
         describe = model.describe()
-        ret[describe.get("name")] = describe
+        ret[describe.get("name")] = dict(describe, managed=managed)
     return ret
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -102,6 +102,7 @@ class Product(Model):
     class Meta:
         unique_together = (("name", "type"),)
         indexes = (("name", "type"),)
+        managed = True
 
 
 class Config(Model):
@@ -117,6 +118,21 @@ class Config(Model):
     )
 
     email: fields.OneToOneRelation[Email]
+
+    class Meta:
+        managed = True
+
+
+class DontManageMe(Model):
+    name = fields.CharField(max_length=50)
+
+    class Meta:
+        managed = False
+
+
+class Ignore(Model):
+    class Meta:
+        managed = False
 
 
 class NewModel(Model):

--- a/tests/old_models.py
+++ b/tests/old_models.py
@@ -89,3 +89,40 @@ class Config(Model):
 
     class Meta:
         table = "configs"
+
+
+class DontManageMe(Model):
+    name = fields.CharField(max_length=50)
+
+    class Meta:
+        table = "dont_manage"
+
+
+class Ignore(Model):
+    name = fields.CharField(max_length=50)
+
+    class Meta:
+        managed = True
+
+
+def main() -> None:
+    """Generate a python file for the old_models_describe"""
+    from pathlib import Path
+
+    from tortoise import run_async
+    from tortoise.contrib.test import init_memory_sqlite
+
+    from aerich.utils import get_models_describe
+
+    @init_memory_sqlite
+    async def run() -> None:
+        old_models_describe = get_models_describe("models")
+        p = Path("old_models_describe.py")
+        p.write_text(f"{old_models_describe = }", encoding="utf-8")
+        print(f"Write value to {p}\nYou can reformat it by `ruff format {p}`")
+
+    run_async(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Close #299 

# TODO
- [x] Add unittest
- [x] Update old_models_describe
- [x] Handle case that change `managed=False` to `managed=True` after several migrations
- [x] Update changelog after v0.8.1 released
- [x] Merge commits into one

# Description
1. if `getattr(MyModel.Meta, 'managed', None) is False`, ignore MyModel in migration file
2. model describe dict will save to the aerich table with a extra `"managed": False` key value
3. when change managed from false to true, the model will compared with the last version of "aerich" table's content

**Note** `managed=False` does not  recognized by `tortoise-orm` and `aerich init-db`, it is only for `aerich migrate`.