### PR TITLE
Remove system dependency on libsqlite3.so on command.upgrade

### DIFF
--- a/aerich/ddl/__init__.py
+++ b/aerich/ddl/__init__.py
@@ -127,11 +127,7 @@ class BaseDDL:
             template = self._MODIFY_COLUMN_TEMPLATE
         else:
             # sqlite does not support alter table to add unique column
-            unique = (
-                " UNIQUE"
-                if field_describe.get("unique") and self.DIALECT != "sqlite"
-                else ""
-            )
+            unique = " UNIQUE" if field_describe.get("unique") and self.DIALECT != "sqlite" else ""
             template = self._ADD_COLUMN_TEMPLATE
         column = self.schema_generator._create_string(
             db_column=db_column,

--- a/aerich/ddl/__init__.py
+++ b/aerich/ddl/__init__.py
@@ -5,7 +5,6 @@ from typing import Any, List, Type, cast
 import tortoise
 from tortoise import BaseDBAsyncClient, Model
 from tortoise.backends.base.schema_generator import BaseSchemaGenerator
-from tortoise.backends.sqlite.schema_generator import SqliteSchemaGenerator
 
 from aerich.utils import is_default_function
 
@@ -130,7 +129,7 @@ class BaseDDL:
             # sqlite does not support alter table to add unique column
             unique = (
                 " UNIQUE"
-                if field_describe.get("unique") and self.DIALECT != SqliteSchemaGenerator.DIALECT
+                if field_describe.get("unique") and self.DIALECT != "sqlite"
                 else ""
             )
             template = self._ADD_COLUMN_TEMPLATE


### PR DESCRIPTION
My application uses in-code migrations:
```python
async def perform_db_migrations():
    command = Command(tortoise_config=settings.tortoise_config, app="app", location=MIGRATION_PATH)
    await command.init()
    await command.upgrade(run_in_transaction=True)
```

When `aerich.ddl.__init__.py` imports SqliteSchemaGenerator:
```python
from tortoise.backends.sqlite.schema_generator import SqliteSchemaGenerator
````

Creates a dependency on libsqlite3.so:
`ImportError: libsqlite3.so.0: cannot open shared object file: No such file or directory`

My production container does not have this dependency, as it expects the application to connect to a DB, and not use sqlite. I've proposed a simple fix in this PR by hardcoding the expected sqlite dialect.