### PR TITLE
feat: support command `python -m aerich`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### [0.8.2]**(Unreleased)**
 
 #### Added
+- feat: support command `python -m aerich`. ([#417])
 - feat: add --fake to upgrade/downgrade. ([#398])
 
 #### Fixed
@@ -18,6 +19,7 @@
 [#401]: https://github.com/tortoise/aerich/pull/401
 [#412]: https://github.com/tortoise/aerich/pull/412
 [#415]: https://github.com/tortoise/aerich/pull/415
+[#417]: https://github.com/tortoise/aerich/pull/417
 
 ### [0.8.1](../../releases/tag/v0.8.1) - 2024-12-27
 

--- a/aerich/__main__.py
+++ b/aerich/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,6 +1,8 @@
 import contextlib
 import os
+import shlex
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -68,3 +70,12 @@ class Dialect:
     def is_sqlite(cls) -> bool:
         cls.load_env()
         return not cls.test_db_url or "sqlite" in cls.test_db_url
+
+
+def run_shell(command: str, capture_output=True, **kw) -> str:
+    r = subprocess.run(shlex.split(command), capture_output=capture_output)
+    if r.returncode != 0 and r.stderr:
+        return r.stderr.decode()
+    if not r.stdout:
+        return ""
+    return r.stdout.decode()

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-import shlex
-import subprocess
 import sys
 from pathlib import Path
 
@@ -11,16 +9,7 @@ import pytest
 
 from aerich.ddl.sqlite import SqliteDDL
 from aerich.migrate import Migrate
-from tests._utils import chdir, copy_files
-
-
-def run_shell(command: str, capture_output=True, **kw) -> str:
-    r = subprocess.run(shlex.split(command), capture_output=capture_output)
-    if r.returncode != 0 and r.stderr:
-        return r.stderr.decode()
-    if not r.stdout:
-        return ""
-    return r.stdout.decode()
+from tests._utils import chdir, copy_files, run_shell
 
 
 @pytest.fixture

--- a/tests/test_python_m.py
+++ b/tests/test_python_m.py
@@ -1,0 +1,6 @@
+from aerich.version import __version__
+from tests._utils import run_shell
+
+
+def test_python_m_aerich():
+    assert __version__ in run_shell("python -m aerich --version")


### PR DESCRIPTION
# Description
Support command `python -m aerich`, e.g.:
```bash
python -m aerich -h
```