### PR TITLE
Release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8
 
-### [0.8.2]**(Unreleased)**
+### [0.8.2](../../releases/tag/v0.8.2) - 2025-02-28
 
 #### Added
 - Support changes `max_length` or int type for primary key field. ([#428])

--- a/poetry.lock
+++ b/poetry.lock
@@ -809,15 +809,15 @@ files = [
 
 [[package]]
 name = "psycopg-pool"
-version = "3.2.5"
+version = "3.2.6"
 description = "Connection Pool for Psycopg"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"psycopg\""
 files = [
-    {file = "psycopg_pool-3.2.5-py3-none-any.whl", hash = "sha256:522b9befae8631550217fd2ae9904622daaf4b28a0a36ccfcc87ba3d2abc7100"},
-    {file = "psycopg_pool-3.2.5.tar.gz", hash = "sha256:507d845bd13da83df449ded7fb581b35dba613421bdb12962e608b16e70d6be9"},
+    {file = "psycopg_pool-3.2.6-py3-none-any.whl", hash = "sha256:5887318a9f6af906d041a0b1dc1c60f8f0dda8340c2572b74e10907b51ed5da7"},
+    {file = "psycopg_pool-3.2.6.tar.gz", hash = "sha256:0f92a7817719517212fbfe2fd58b8c35c1850cdd2a80d36b581ba2085d9148e5"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerich"
-version = "0.8.1"
+version = "0.8.2"
 description = "A database migrations tool for Tortoise ORM."
 authors = [{name="long2ice", email="long2ice@gmail.com>"}]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## 0.8.2

### Added
- Support changes `max_length` or int type for primary key field. (#428)
- feat: support psycopg. (#425)
- Support run `poetry add aerich` in project that inited by poetry v2. (#424)
- feat: support command `python -m aerich`. (#417)
- feat: add --fake to upgrade/downgrade. (#398)
- Support ignore table by settings `managed=False` in `Meta` class. (#397)

### Fixed
- fix: aerich migrate raises tortoise.exceptions.FieldError when `index.INDEX_TYPE` is not empty. (#415)
- No migration occurs as expected when adding `unique=True` to indexed field. (#404)
- fix: inspectdb raise KeyError 'int2' for smallint. (#401)
- fix: inspectdb not match data type 'DOUBLE' and 'CHAR' for MySQL. (#187)

### Changed
- Refactored version management to use `importlib.metadata.version(__package__)` instead of hardcoded version string (#412)