### PR TITLE
fix: ci failed with m2m field migrate test

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -114,7 +114,7 @@ def _init_tortoise_0_24_1_patch():
                     "",
                 )  # may have better way
             m2m_create_string += self._post_table_hook()
-            if field_object.create_unique_index:
+            if getattr(field_object, "create_unique_index", field_object.unique):
                 unique_index_create_sql = self._get_unique_index_sql(
                     exists, through_table_name, [backward_key, forward_key]
                 )
@@ -129,7 +129,7 @@ def _init_tortoise_0_24_1_patch():
             m2m_tables_for_create.append(m2m_create_string)
         return m2m_tables_for_create
 
-    BaseSchemaGenerator._get_m2m_tables = _get_m2m_tables  # type:ignore[attr-defined]
+    setattr(BaseSchemaGenerator, "_get_m2m_tables", _get_m2m_tables)
 
 
 _init_asyncio_patch()

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -270,7 +270,19 @@ class Migrate:
             if field.get("managed") is not False
         }
         for action, option, change in get_dict_diff_by_key(old_m2m_fields, new_m2m_fields):
-            if (option and option[-1] == "nullable") or change[0][0] == "db_constraint":
+            if action == "change":
+                # Example:: action = 'change'; option = [0, 'unique']; change = (False, True)
+                attr = option[-1]
+                if attr == "indexed":
+                    # Ignore changing of indexed, as it usually changed by unique
+                    continue
+                elif attr == "unique":
+                    # TODO:
+                    continue
+                elif attr == "nullable":
+                    # nullable of m2m relation is constrainted by orm framework, not by db
+                    continue
+            if change[0][0] == "db_constraint":
                 continue
             new_value = change[0][1]
             if isinstance(new_value, str):


### PR DESCRIPTION
CI failed as `tortoise-orm==0.24.2` released, which use `unique` intead of `create_unique_index` for m2m field.