### PR TITLE
fix: aerich migrate crashes without init-db & aerich init-db should create folder after validating app

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -256,13 +256,6 @@ class Command(AbstractAsyncContextManager):
     async def init_db(self, safe: bool) -> None:
         location = self.location
         app = self.app
-        dirname = Path(location, app)
-        if not dirname.exists():
-            dirname.mkdir(parents=True)
-        else:
-            # If directory is empty, go ahead, otherwise raise FileExistsError
-            for unexpected_file in dirname.glob("*"):
-                raise FileExistsError(str(unexpected_file))
 
         await Tortoise.init(config=self.tortoise_config)
         connection = get_app_connection(self.tortoise_config, app)

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -266,6 +266,15 @@ class Command(AbstractAsyncContextManager):
 
         await Tortoise.init(config=self.tortoise_config)
         connection = get_app_connection(self.tortoise_config, app)
+
+        dirname = Path(location, app)
+        if not dirname.exists():
+            dirname.mkdir(parents=True)
+        else:
+            # If directory is empty, go ahead, otherwise raise FileExistsError
+            for unexpected_file in dirname.glob("*"):
+                raise FileExistsError(str(unexpected_file))
+
         await generate_schema_for_client(connection, safe)
 
         schema = get_schema_sql(connection, safe)

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -172,7 +172,7 @@ class Migrate:
         if empty:
             return await cls._generate_diff_py(name)
         new_version_content = get_models_describe(cls.app)
-        last_version = cast(dict, cls._last_version_content) or {}
+        last_version = cast(dict, cls._last_version_content)
         cls.diff_models(last_version, new_version_content)
         cls.diff_models(new_version_content, last_version, False)
 
@@ -398,7 +398,13 @@ class Migrate:
         :return:
         """
         _aerich = f"{cls.app}.{cls._aerich}"
-        old_models.pop(_aerich, None)
+        try:
+            old_models.pop(_aerich, None)
+        except AttributeError:
+            # Invalid use when app migration directory exists but aerich table not exist
+            raise click.UsageError(
+                "You may need to run `aerich init-db` first to initialize the database."
+            )
         new_models.pop(_aerich, None)
         models_with_rename_field: set[str] = set()  # models that trigger the click.prompt
 

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -172,7 +172,7 @@ class Migrate:
         if empty:
             return await cls._generate_diff_py(name)
         new_version_content = get_models_describe(cls.app)
-        last_version = cast(dict, cls._last_version_content)
+        last_version = cast(dict, cls._last_version_content) or {}
         cls.diff_models(last_version, new_version_content)
         cls.diff_models(new_version_content, last_version, False)
 


### PR DESCRIPTION
## 📌 Issue: Two Problems with `aerich migrate` and `init-db` Behavior

### 💥 Problem 1: `aerich migrate` crashes if `init-db` was not run

**Steps to Reproduce:**

1. Run `aerich init`
2. Do **not** run `aerich init-db`
3. Run `aerich migrate`

**Observed Error:**
```python
File "/path/to/aerich/migrate.py", line 176, in migrate
    cls.diff_models(last_version, new_version_content)
File "/path/to/aerich/migrate.py", line 390, in diff_models
    old_models.pop(_aerich, None)
AttributeError: 'NoneType' object has no attribute 'pop'
```

### 💥 Problem 2: `aerich init-db` should create folder before validating app

**Steps to Reproduce:**

1. Add an invalid or non-existent app to the Aerich config
2. Run aerich --app non_existed init-db

**Observed Error:**
```python
Error: Can't get app named 'non_existed'  # but the migration folder created
```