### PR TITLE
fix: m2m migrate raises TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # ChangeLog
 
-## 0.8
+## 0.9
+### [0.9.0]**(Unreleased)**
 
-### [0.8.3]**(Unreleased)**
+### Changed
+- Drop support for Python3.8. ([#446])
 
 #### Fixed
+- fix: m2m migrate raises TypeError. ([#448])
 - fix: `aerich init-db` process is suspended. ([#435])
 
+[#448]: https://github.com/tortoise/aerich/pull/448
+[#446]: https://github.com/tortoise/aerich/pull/446
 [#435]: https://github.com/tortoise/aerich/pull/435
+
+## 0.8
 
 ### [0.8.2](../../releases/tag/v0.8.2) - 2025-02-28
 

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import os
 from collections.abc import Iterable
@@ -276,14 +277,20 @@ class Migrate:
                 if attr == "indexed":
                     # Ignore changing of indexed, as it usually changed by unique
                     continue
-                elif attr == "unique":
-                    # TODO:
-                    continue
                 elif attr == "nullable":
                     # nullable of m2m relation is constrainted by orm framework, not by db
                     continue
-            if change[0][0] == "db_constraint":
-                continue
+                elif attr in ("unique", "db_constraint"):
+                    # TODO: handle 'unique'
+                    if upgrade:
+                        click.secho(
+                            f"Aerich does not handle {attr!r} attribution for m2m field. You may need to change the constraints in db manually.",
+                            fg=Color.yellow,
+                        )
+                    continue
+            with contextlib.suppress(TypeError, KeyError):
+                if change[0][0] == "db_constraint":
+                    continue
             new_value = change[0][1]
             if isinstance(new_value, str):
                 for new_m2m_field in new_m2m_fields:

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -938,7 +938,7 @@ old_models_describe = {
 }
 
 
-def test_migrate(mocker: MockerFixture):
+def test_migrate(mocker: MockerFixture, capsys):
     """
     models.py diff with old_models.py
     - change email pk: id -> email_id
@@ -980,6 +980,7 @@ def test_migrate(mocker: MockerFixture):
         Migrate.diff_models(old_models_describe, models_describe)
         Migrate.diff_models(models_describe, old_models_describe, False)
         Migrate._merge_operators()
+    warning_msg = "Aerich does not handle 'unique' attribution for m2m field. You may need to change the constraints in db manually."
     if isinstance(Migrate.ddl, MysqlDDL):
         expected_upgrade_operators = {
             "ALTER TABLE `category` MODIFY COLUMN `name` VARCHAR(200)",
@@ -1080,6 +1081,7 @@ def test_migrate(mocker: MockerFixture):
         assert not downgrade_more_than_expected
         downgrade_less_than_expected = expected_downgrade_operators - downgrade_operators
         assert not downgrade_less_than_expected
+        assert warning_msg in capsys.readouterr().out
 
     elif isinstance(Migrate.ddl, PostgresDDL):
         expected_upgrade_operators = {
@@ -1183,6 +1185,7 @@ def test_migrate(mocker: MockerFixture):
         assert not downgrade_more_than_expected
         downgrade_less_than_expected = expected_downgrade_operators - downgrade_operators
         assert not downgrade_less_than_expected
+        assert warning_msg in capsys.readouterr().out
 
     elif isinstance(Migrate.ddl, SqliteDDL):
         assert Migrate.upgrade_operators == []


### PR DESCRIPTION
Fixes #444 

Currently, aerich does not handle changes of some attributions for m2m field migrating, such as null/unique/db_constraint. 
This PR add a warning message for it.

For example::
- old
```py
from tortoise import Model, fields
class Group(Model):
    name = fields.CharField(max_length=30)

class User(Model):
    groups = fields.ManyToManyField('models.Group', unique=False)
```
- new
```py
from tortoise import Model, fields
class Group(Model):
    name = fields.CharField(max_length=30)

class User(Model):
    groups = fields.ManyToManyField('models.Group', unique=True)
```
Run `aerich migrate` will get this warning message:
```
Aerich does not handle 'unique' attribution for m2m field. You may need to change the constraints in db manually.
```