### PR TITLE
feat: ask confirm before delete same version migration file

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -4,7 +4,7 @@ import os
 import platform
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import tortoise
 from tortoise import Tortoise, connections, generate_schema_for_client
@@ -250,9 +250,20 @@ class Command(AbstractAsyncContextManager):
         inspect = cls(connection, tables)
         return await inspect.inspect()
 
+    @overload
+    async def migrate(
+        self, name: str = "update", empty: bool = False, no_input: Literal[True] = True
+    ) -> str: ...
+
+    @overload
+    async def migrate(
+        self, name: str = "update", empty: bool = False, no_input: bool = False
+    ) -> str | None: ...
+
     async def migrate(
         self, name: str = "update", empty: bool = False, no_input: bool = False
     ) -> str | None:
+        # return None if same version migration file already exists, and new one not generated
         return await Migrate.migrate(name, empty, no_input)
 
     async def init_db(self, safe: bool) -> None:

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -252,7 +252,7 @@ class Command(AbstractAsyncContextManager):
 
     async def migrate(
         self, name: str = "update", empty: bool = False, no_input: bool = False
-    ) -> str:
+    ) -> str | None:
         return await Migrate.migrate(name, empty, no_input)
 
     async def init_db(self, safe: bool) -> None:

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -95,9 +95,12 @@ async def migrate(ctx: Context, name, empty, no_input) -> None:
     command = ctx.obj["command"]
     ret = await command.migrate(name, empty, no_input)
     if ret is None:
+        return click.secho(
+            "Aborted! You may need to run `aerich heads` to list avaliable unapplied migrations.",
+            fg=Color.yellow,
+        )
+    if not ret:
         return click.secho("No changes detected", fg=Color.yellow)
-    elif not ret:
-        return click.secho("Please check the content of existing migration files", fg=Color.yellow)
     click.secho(f"Success creating migration file {ret}", fg=Color.green)
 
 

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -94,8 +94,10 @@ async def cli(ctx: Context, config, app) -> None:
 async def migrate(ctx: Context, name, empty, no_input) -> None:
     command = ctx.obj["command"]
     ret = await command.migrate(name, empty, no_input)
-    if not ret:
+    if ret is None:
         return click.secho("No changes detected", fg=Color.yellow)
+    elif not ret:
+        return click.secho("Please check the content of existing migration files", fg=Color.yellow)
     click.secho(f"Success creating migration file {ret}", fg=Color.green)
 
 

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -74,7 +74,7 @@ async def cli(ctx: Context, config, app) -> None:
             try:
                 apps_config = cast(dict, tortoise_config["apps"])
             except KeyError:
-                raise UsageError('Config must define "apps" section')
+                raise UsageError('Config must define "apps" section') from None
             app = list(apps_config.keys())[0]
         command = Command(tortoise_config=tortoise_config, app=app, location=location)
         ctx.obj["command"] = command

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -138,7 +138,7 @@ class Migrate:
         return version
 
     @classmethod
-    async def _generate_diff_py(cls, name, no_input: bool = False) -> str:
+    async def _generate_diff_py(cls, name, no_input: bool = False) -> str | None:
         content = cls._get_diff_file_content()
         version = await cls.generate_version(name)  # '<num>_<date>_<name>.py'
         conflict_files = [
@@ -159,8 +159,8 @@ class Migrate:
                 show_choices=True,
             )
             if not overwrite:
-                return ""
-            # delete if same version exists
+                return None
+            # delete same version files
             for version_file in conflict_files:
                 os.unlink(Path(cls.migrate_location, version_file))
 
@@ -185,7 +185,7 @@ class Migrate:
 
     @overload
     @classmethod
-    async def migrate(cls, name: str, empty: Literal[True], no_input: bool = False) -> str: ...
+    async def migrate(cls, name: str, empty: bool, no_input: Literal[True]) -> str: ...
 
     @overload
     @classmethod
@@ -200,7 +200,7 @@ class Migrate:
         :return:
         """
         if empty:
-            return await cls._generate_diff_py(name)
+            return await cls._generate_diff_py(name, no_input=no_input)
         new_version_content = get_models_describe(cls.app)
         last_version = cast(dict, cls._last_version_content)
         cls.diff_models(last_version, new_version_content, no_input=no_input)
@@ -209,7 +209,7 @@ class Migrate:
         cls._merge_operators()
 
         if not cls.upgrade_operators:
-            return None
+            return ""
 
         return await cls._generate_diff_py(name, no_input=no_input)
 

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -462,7 +462,7 @@ class Migrate:
             # Invalid use when app migration directory exists but aerich table not exist
             raise click.UsageError(
                 "You may need to run `aerich init-db` first to initialize the database."
-            )
+            ) from None
         new_models.pop(_aerich, None)
         models_with_rename_field: set[str] = set()  # models that trigger the click.prompt
 

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast, overload
 
 import asyncclick as click
 from dictdiffer import diff
@@ -138,14 +138,32 @@ class Migrate:
         return version
 
     @classmethod
-    async def _generate_diff_py(cls, name) -> str:
-        version = await cls.generate_version(name)
-        # delete if same version exists
-        for version_file in cls.get_all_version_files():
-            if version_file.startswith(version.split("_")[0]):
+    async def _generate_diff_py(cls, name, no_input: bool = False) -> str:
+        content = cls._get_diff_file_content()
+        version = await cls.generate_version(name)  # '<num>_<date>_<name>.py'
+        conflict_files = [
+            version_file
+            for version_file in cls.get_all_version_files()
+            if version_file.startswith(version.split("_")[0])
+        ]
+        if conflict_files:
+            if len(conflict_files) == 1:
+                file = Path(cls.migrate_location, conflict_files[0])
+                tip = f"Miration file exists({file}). Do you want to remove it?"
+            else:
+                tip = f"Miration file exists({conflict_files}). Do you want to remove them?"
+            overwrite = no_input or click.prompt(
+                tip,
+                default=False,
+                type=bool,
+                show_choices=True,
+            )
+            if not overwrite:
+                return ""
+            # delete if same version exists
+            for version_file in conflict_files:
                 os.unlink(Path(cls.migrate_location, version_file))
 
-        content = cls._get_diff_file_content()
         Path(cls.migrate_location, version).write_text(content, encoding="utf-8")
         return version
 
@@ -165,8 +183,16 @@ class Migrate:
             )
         ]
 
+    @overload
     @classmethod
-    async def migrate(cls, name: str, empty: bool, no_input: bool = False) -> str:
+    async def migrate(cls, name: str, empty: Literal[True], no_input: bool = False) -> str: ...
+
+    @overload
+    @classmethod
+    async def migrate(cls, name: str, empty: bool, no_input: bool = False) -> str | None: ...
+
+    @classmethod
+    async def migrate(cls, name: str, empty: bool, no_input: bool = False) -> str | None:
         """
         diff old models and new models to generate diff content
         :param name: str name for migration
@@ -183,9 +209,9 @@ class Migrate:
         cls._merge_operators()
 
         if not cls.upgrade_operators:
-            return ""
+            return None
 
-        return await cls._generate_diff_py(name)
+        return await cls._generate_diff_py(name, no_input=no_input)
 
     @classmethod
     def _get_diff_file_content(cls) -> str:

--- a/tests/assets/migrate_no_input/_tests.py
+++ b/tests/assets/migrate_no_input/_tests.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from asyncclick.testing import CliRunner
+
+from aerich.cli import cli
+from aerich.migrate import Migrate
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_migrate():
+    runner = CliRunner()
+    # Default to abort without deleting previous generated migration files
+    result = await runner.invoke(cli, ["migrate"], input="\n")
+    assert not result.exception
+    assert "it" in result.output
+    warning_msg = (
+        "Aborted! You may need to run `aerich heads` to list avaliable unapplied migrations."
+    )
+    assert warning_msg in result.output
+    migrate_dir = Path(Migrate.migrate_location)
+    extra_migration_file = migrate_dir.joinpath("1_datetime_update.py")
+    extra_migration_file.touch()
+    pre_migration_files = list(migrate_dir.glob("1_*.py"))
+    updated_at_0 = pre_migration_files[0].stat().st_mtime
+    # Delete migration files that with same version num when explicit input True
+    result = await runner.invoke(cli, ["migrate"], input="True\n")
+    assert not result.exception
+    assert "them" in result.output
+    assert all(i.name in result.output for i in pre_migration_files)
+    assert not extra_migration_file.exists()
+    new_migration_files = list(migrate_dir.glob("1_*.py"))
+    assert len(new_migration_files) == 1
+    updated_at = new_migration_files[0].stat().st_mtime
+    assert updated_at > updated_at_0
+    # Delete migration files without ask for prompt when --no-input passed
+    result = await runner.invoke(cli, ["migrate", "--no-input"])
+    assert not result.exception
+    assert "them" not in result.output and "it" not in result.output
+    latest_migration_files = list(migrate_dir.glob("1_*.py"))
+    assert len(latest_migration_files) == 1
+    updated_at_2 = latest_migration_files[0].stat().st_mtime
+    assert updated_at_2 > updated_at

--- a/tests/assets/migrate_no_input/models.py
+++ b/tests/assets/migrate_no_input/models.py
@@ -1,0 +1,5 @@
+from tortoise import Model, fields
+
+
+class Foo(Model):
+    name = fields.CharField(10)

--- a/tests/assets/migrate_no_input/settings.py
+++ b/tests/assets/migrate_no_input/settings.py
@@ -1,0 +1,4 @@
+TORTOISE_ORM = {
+    "connections": {"default": "sqlite://db.sqlite3"},
+    "apps": {"models": {"models": ["models", "aerich.models"]}},
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,61 +1,50 @@
 from __future__ import annotations
 
+import shutil
+import time
 from pathlib import Path
 
-import anyio
 import pytest
-from asyncclick.testing import CliRunner
 
-from aerich.cli import cli
-from aerich.migrate import Migrate
-from tests._utils import chdir
-
-MODEL_TEXT = """from tortoise import Model, fields
-class NewModel(Model):
-    name = fields.CharField(10)
-"""
-SETTINGS = """TORTOISE_ORM = {
-    "connections": {"default": 'sqlite://db.sqlite3'},
-    "apps": {"models": {"models": ["models", "aerich.models"]},},
-}"""
+from tests._utils import chdir, run_shell
 
 
 @pytest.fixture
 def new_project(tmp_path):
+    asset_dir = Path(__file__).parent / "assets" / "migrate_no_input"
     with chdir(tmp_path):
-        Path("models.py").write_text(MODEL_TEXT)
-        Path("settings.py").write_text(SETTINGS)
-        yield
+        for file in asset_dir.glob("*.py"):
+            shutil.copy(file, file.name)
+        run_shell("aerich init -t settings.TORTOISE_ORM", capture_output=False)
+        run_shell("aerich init-db", capture_output=False)
+        yield tmp_path
 
 
-async def test_migrate_command_output(mocker, new_project) -> None:
-    runner = CliRunner()
-    result = await runner.invoke(cli, ["init", "-t", "settings.TORTOISE_ORM"])
-    assert not result.exception
-    result = await runner.invoke(cli, ["init-db"])
-    assert not result.exception
-    result = await runner.invoke(cli, ["migrate"])
-    assert not result.exception
-    assert "No changes detected" in result.output
-    result = await runner.invoke(cli, ["migrate", "--empty"], input="False\n")
-    assert not result.exception
-    assert "success" in result.output.lower()
-    empty_migration_files = list(Path(Migrate.migrate_location).glob("1_*.py"))
+def test_empty_migrate_with_no_input(mocker, new_project) -> None:
+    output = run_shell("aerich migrate", cwd=new_project)
+    assert "No changes detected" in output
+    output = run_shell("aerich migrate --empty", cwd=new_project)
+    assert "Success" in output
+    migrate_dir = Path("migrations/models")
+    empty_migration_files = list(migrate_dir.glob("1_*.py"))
     assert len(empty_migration_files) == 1
-    await anyio.Path("models.py").write_text(MODEL_TEXT + "    age=fields.IntField()\n")
-    await anyio.lowlevel.checkpoint()
-    result = await runner.invoke(cli, ["migrate", "--empty"], input="False\n")
-    assert not result.exception
-    warning_msg = (
-        "Aborted! You may need to run `aerich heads` to list avaliable unapplied migrations."
-    )
-    assert warning_msg in result.output
-    assert list(Path(Migrate.migrate_location).glob("1_*.py")) == empty_migration_files
-    await anyio.sleep(1)  # ensure new migration filename generated.
-    result = await runner.invoke(cli, ["migrate", "--empty"], input="True\n")
-    new_empty_migration_files = list(Path(Migrate.migrate_location).glob("1_*.py"))
+    time.sleep(1)  # ensure new migration filename generated.
+    run_shell("aerich migrate --empty --no-input", cwd=new_project)
+    new_empty_migration_files = list(migrate_dir.glob("1_*.py"))
     assert len(new_empty_migration_files) == 1
     assert empty_migration_files != new_empty_migration_files
-    result = await runner.invoke(cli, ["migrate"], input="False\n")
-    assert not result.exception
-    assert warning_msg in result.output
+
+
+@pytest.fixture
+async def project_with_unapplied_migrations(new_project):
+    models_py = Path("models.py")
+    text = models_py.read_text()
+    if "age" not in text:
+        models_py.write_text(text + "    age=fields.IntField()\n")
+    run_shell("aerich migrate", cwd=new_project)
+
+
+def test_migrate_with_same_version_file_exists(project_with_unapplied_migrations) -> None:
+    # CliRunner change the entire interpreter state, so run it in subprocess
+    output = run_shell("pytest _tests.py")
+    assert "1 passed" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import pytest
+from asyncclick.testing import CliRunner
+
+from aerich.cli import cli
+from aerich.migrate import Migrate
+from tests._utils import chdir
+
+MODEL_TEXT = """from tortoise import Model, fields
+class NewModel(Model):
+    name = fields.CharField(10)
+"""
+SETTINGS = """TORTOISE_ORM = {
+    "connections": {"default": 'sqlite://db.sqlite3'},
+    "apps": {"models": {"models": ["models", "aerich.models"]},},
+}"""
+
+
+@pytest.fixture
+def new_project(tmp_path):
+    with chdir(tmp_path):
+        Path("models.py").write_text(MODEL_TEXT)
+        Path("settings.py").write_text(SETTINGS)
+        yield
+
+
+async def test_migrate_command_output(mocker, new_project) -> None:
+    runner = CliRunner()
+    result = await runner.invoke(cli, ["init", "-t", "settings.TORTOISE_ORM"])
+    assert not result.exception
+    result = await runner.invoke(cli, ["init-db"])
+    assert not result.exception
+    result = await runner.invoke(cli, ["migrate"])
+    assert not result.exception
+    assert "No changes detected" in result.output
+    result = await runner.invoke(cli, ["migrate", "--empty"], input="False\n")
+    assert not result.exception
+    assert "success" in result.output.lower()
+    empty_migration_files = list(Path(Migrate.migrate_location).glob("1_*.py"))
+    assert len(empty_migration_files) == 1
+    await anyio.Path("models.py").write_text(MODEL_TEXT + "    age=fields.IntField()\n")
+    await anyio.lowlevel.checkpoint()
+    result = await runner.invoke(cli, ["migrate", "--empty"], input="False\n")
+    assert not result.exception
+    warning_msg = (
+        "Aborted! You may need to run `aerich heads` to list avaliable unapplied migrations."
+    )
+    assert warning_msg in result.output
+    assert list(Path(Migrate.migrate_location).glob("1_*.py")) == empty_migration_files
+    await anyio.sleep(1)  # ensure new migration filename generated.
+    result = await runner.invoke(cli, ["migrate", "--empty"], input="True\n")
+    new_empty_migration_files = list(Path(Migrate.migrate_location).glob("1_*.py"))
+    assert len(new_empty_migration_files) == 1
+    assert empty_migration_files != new_empty_migration_files
+    result = await runner.invoke(cli, ["migrate"], input="False\n")
+    assert not result.exception
+    assert warning_msg in result.output

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import anyio
 import pytest
 import tortoise
 from pytest_mock import MockerFixture
@@ -13,7 +14,9 @@ from aerich.ddl.postgres import PostgresDDL
 from aerich.ddl.sqlite import SqliteDDL
 from aerich.exceptions import NotSupportError
 from aerich.migrate import MIGRATE_TEMPLATE, Migrate
+from aerich.models import Aerich
 from aerich.utils import get_models_describe
+from tests._utils import chdir
 from tests.indexes import CustomIndex
 
 
@@ -1237,13 +1240,72 @@ def test_sort_files_containing_non_migrations(mocker):
     ]
 
 
-async def test_empty_migration(mocker, tmp_path: Path) -> None:
-    mocker.patch("os.listdir", return_value=[])
+@pytest.fixture
+def tmp_migrate_dir(tmp_path):
     Migrate.app = "foo"
-    expected_content = MIGRATE_TEMPLATE.format(upgrade_sql="", downgrade_sql="")
     Migrate.migrate_location = tmp_path
+    with chdir(tmp_path):
+        yield
 
-    migration_file = await Migrate.migrate("update", True)
 
-    f = tmp_path / migration_file
-    assert f.read_text() == expected_content
+async def test_empty_migration(mocker, tmp_migrate_dir) -> None:
+    mocker.patch("os.listdir", return_value=[])
+    expected_content = MIGRATE_TEMPLATE.format(upgrade_sql="", downgrade_sql="")
+
+    migration_file = await Migrate.migrate("update", True, no_input=True)
+    assert Path(migration_file).read_text() == expected_content
+
+
+async def test_remove_conflicts_empty(mocker, tmp_migrate_dir) -> None:
+    # empty migration
+    expected_content = MIGRATE_TEMPLATE.format(upgrade_sql="", downgrade_sql="")
+    pre_migrate_file = Path("0_datetime_name.py")
+    pre_migrate_file.write_text("Invalid migration content")
+    mocker.patch("asyncclick.prompt", side_effect=(False,))
+    migration_file = await Migrate.migrate("update", empty=True)
+    assert pre_migrate_file.exists()
+    assert migration_file is None
+
+    mocker.patch("asyncclick.prompt", side_effect=(True,))
+    migration_file = await Migrate.migrate("update", empty=True)
+    assert not pre_migrate_file.exists()
+    assert migration_file and migration_file.startswith("0_")
+    assert Path(migration_file).read_text() == expected_content
+
+    await anyio.sleep(1)  # ensure new migration filename to be generated
+    new_migration_file = await Migrate.migrate("update", empty=True, no_input=True)
+    assert not Path(migration_file).exists()
+    assert new_migration_file.startswith("0_")
+    assert Path(new_migration_file).read_text() == expected_content
+
+
+async def test_remove_conflicts(mocker, tmp_migrate_dir) -> None:
+    from tests.models import NewModel
+
+    # normal migration
+    mocker.patch("aerich.migrate.get_models_describe", return_value={})
+    mocker.patch("aerich.utils.get_models_describe", return_value={})
+    Migrate._last_version_content = {}
+    init_file = Path("0_datetime_init.py")
+    init_file.touch()
+    pre_migrate_file = Path("1_datetime_name.py")
+    pre_migrate_file.write_text("Invalid migration content")
+    mocker.patch("asyncclick.prompt", side_effect=(False,))
+    migration_file = await Migrate.migrate("update", empty=False)
+    assert pre_migrate_file.exists()
+    assert migration_file == ""
+
+    models_describe = {"foo.NewModel": get_models_describe("models")["models.NewModel"]}
+    last_version = Aerich(app="foo", content="{}", version=init_file.name)
+    mocker.patch("asyncclick.prompt", side_effect=(True,))
+    mocker.patch("aerich.migrate.get_models_describe", return_value=models_describe)
+    mocker.patch("aerich.migrate.Migrate.get_last_version", return_value=last_version)
+    mocker.patch("aerich.migrate.Migrate._get_model", return_value=NewModel)
+    migration_file = await Migrate.migrate("update", empty=False)
+    assert not pre_migrate_file.exists()
+    assert migration_file and migration_file.startswith("1_")
+
+    await anyio.sleep(1)  # ensure new migration filename to be generated
+    new_migration_file = await Migrate.migrate("update", empty=True, no_input=True)
+    assert not Path(migration_file).exists()
+    assert new_migration_file and new_migration_file.startswith("1_")


### PR DESCRIPTION
Closes #245

1. Prompt to determine whether remove previous generated migration files that with same version.
2. Support pass `--no-input` option to avoid asking.