### PR TITLE
fix: `Command.migrate()` programmatically raises KeyError

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import os
 import platform
+from collections.abc import Generator
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import tortoise
 from tortoise import BaseDBAsyncClient, Tortoise, connections
@@ -12,7 +13,7 @@ from tortoise.exceptions import OperationalError
 from tortoise.transactions import in_transaction
 from tortoise.utils import generate_schema_for_client, get_schema_sql
 
-from aerich.exceptions import DowngradeError
+from aerich.exceptions import DowngradeError, NotInitedError
 from aerich.inspectdb.mysql import InspectMySQL
 from aerich.inspectdb.postgres import InspectPostgres
 from aerich.inspectdb.sqlite import InspectSQLite
@@ -162,6 +163,13 @@ class Command(AbstractAsyncContextManager):
         await self.init()
         return self
 
+    def __await__(self) -> Generator[Any, None, Command]:
+        # To support `command = await Command(tortoise_config)`
+        async def _self() -> Command:
+            return await self.__aenter__()
+
+        return _self().__await__()
+
     async def close(self) -> None:
         await connections.close_all()
 
@@ -273,7 +281,10 @@ class Command(AbstractAsyncContextManager):
         self, name: str = "update", empty: bool = False, no_input: bool = False
     ) -> str | None:
         # return None if same version migration file already exists, and new one not generated
-        return await Migrate.migrate(name, empty, no_input)
+        try:
+            return await Migrate.migrate(name, empty, no_input)
+        except NotInitedError as e:
+            raise NotInitedError("You have to call .init() first before migrate") from e
 
     async def init_db(self, safe: bool) -> None:
         location = self.location
@@ -295,12 +306,14 @@ class Command(AbstractAsyncContextManager):
         schema = get_schema_sql(connection, safe)
 
         version = await Migrate.generate_version()
+        aerich_content = get_models_describe(app)
         await Aerich.create(
             version=version,
             app=app,
-            content=get_models_describe(app),
+            content=aerich_content,
         )
         version_file = Path(dirname, version)
         content = MIGRATE_TEMPLATE.format(upgrade_sql=schema, downgrade_sql="")
         with open(version_file, "w", encoding="utf-8") as f:
             f.write(content)
+        Migrate._last_version_content = aerich_content

--- a/aerich/exceptions.py
+++ b/aerich/exceptions.py
@@ -1,10 +1,20 @@
-class NotSupportError(Exception):
+class AerichError(Exception):
+    pass
+
+
+class NotSupportError(AerichError):
     """
     raise when features not support
     """
 
 
-class DowngradeError(Exception):
+class DowngradeError(AerichError):
     """
     raise when downgrade error
+    """
+
+
+class NotInitedError(AerichError):
+    """
+    raise when Tortoise not inited
     """

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -13,6 +13,9 @@ from anyio import from_thread
 from asyncclick import BadOptionUsage, ClickException, Context
 from dictdiffer import diff
 from tortoise import BaseDBAsyncClient, Tortoise
+from tortoise.log import logger
+
+from aerich.exceptions import NotInitedError
 
 if sys.version_info >= (3, 11):
     from typing import ParamSpec, TypeVarTuple, Unpack
@@ -95,7 +98,14 @@ def get_models_describe(app: str) -> dict:
     :return:
     """
     ret = {}
-    for model in Tortoise.apps[app].values():
+    try:
+        app_config = Tortoise.apps[app]
+    except KeyError as e:
+        if not Tortoise._inited:
+            raise NotInitedError("Tortoise not inited yet.") from e
+        logger.debug(f"{Tortoise.apps.keys() = }")
+        raise e
+    for model in app_config.values():
         managed = getattr(model.Meta, "managed", None)
         describe = model.describe()
         ret[describe.get("name")] = dict(describe, managed=managed)

--- a/tests/assets/command_programmatically/_tests.py
+++ b/tests/assets/command_programmatically/_tests.py
@@ -1,0 +1,71 @@
+import re
+from pathlib import Path
+
+import pytest
+from models import Foo
+from settings import TORTOISE_ORM
+from tortoise import Tortoise, connections
+
+from aerich import Command
+from aerich.exceptions import NotInitedError
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def init_connections():
+    await Tortoise.init(TORTOISE_ORM)
+    try:
+        yield
+    finally:
+        await connections.close_all()
+
+
+@pytest.mark.anyio
+async def test_command_not_inited():
+    command = Command(TORTOISE_ORM)
+    message = "You have to call .init() first before migrate"
+    with pytest.raises(NotInitedError, match=re.escape(message)):
+        await command.migrate()
+
+
+@pytest.mark.anyio
+async def test_init_command_by_await():
+    command = await Command(TORTOISE_ORM)
+    if not list(Path("migrations/models").glob("*.py")):
+        await command.init_db(safe=True)
+    await command.migrate()
+    await command.upgrade()
+    await command.close()
+
+
+@pytest.mark.anyio
+async def test_init_command_by_async_with():
+    async with Command(TORTOISE_ORM) as command:
+        if not list(Path("migrations/models").glob("*.py")):
+            await command.init_db(safe=True)
+        await command.migrate()
+        await command.upgrade()
+
+
+@pytest.mark.anyio
+async def test_init_command_by_init_func():
+    command = Command(TORTOISE_ORM)
+    await command.init()
+    if not list(Path("migrations/models").glob("*.py")):
+        await command.init_db(safe=True)
+    await command.migrate()
+    await command.upgrade()
+    await command.close()
+
+
+@pytest.mark.anyio
+async def test_migrate_upgrade(init_connections):
+    async with Command(TORTOISE_ORM) as command:
+        await command.migrate()
+        await command.upgrade()
+    assert list(Path("migrations/models").glob("1_*.py"))
+    await Foo.create(a=1, b=2)

--- a/tests/assets/command_programmatically/models.py
+++ b/tests/assets/command_programmatically/models.py
@@ -1,0 +1,5 @@
+from tortoise import Model, fields
+
+
+class Foo(Model):
+    a = fields.IntField()

--- a/tests/assets/command_programmatically/models_2.py
+++ b/tests/assets/command_programmatically/models_2.py
@@ -1,0 +1,6 @@
+from tortoise import Model, fields
+
+
+class Foo(Model):
+    a = fields.IntField()
+    b = fields.IntField()

--- a/tests/assets/command_programmatically/settings.py
+++ b/tests/assets/command_programmatically/settings.py
@@ -1,0 +1,4 @@
+TORTOISE_ORM = {
+    "connections": {"default": "sqlite://db.sqlite3"},
+    "apps": {"models": {"models": ["models", "aerich.models"]}},
+}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,5 +1,8 @@
+import shutil
+
 from aerich import Command
 from conftest import tortoise_orm
+from tests._utils import prepare_py_files, run_shell
 
 
 async def test_command(mocker):
@@ -9,3 +12,19 @@ async def test_command(mocker):
         heads = await command.heads()
     assert history == []
     assert heads == []
+
+
+def test_await_command(tmp_work_dir):
+    prepare_py_files("command_programmatically")
+    run_shell("aerich init -t settings.TORTOISE_ORM", capture_output=False)
+    output = run_shell("pytest -s _tests.py::test_command_not_inited")
+    assert "error" not in output.lower()
+    output = run_shell("pytest -s _tests.py::test_init_command_by_async_with")
+    assert "error" not in output.lower()
+    output = run_shell("pytest -s _tests.py::test_init_command_by_await")
+    assert "error" not in output.lower()
+    output = run_shell("pytest -s _tests.py::test_init_command_by_init_func")
+    assert "error" not in output.lower()
+    shutil.move("models_2.py", "models.py")
+    output = run_shell("pytest -s _tests.py::test_migrate_upgrade")
+    assert "error" not in output.lower()


### PR DESCRIPTION
Closes #447

1. support `command = await Command()`
2. raise `aerich.exceptions.NotInitedError` instead of `KeyError` when migrate before command inited