### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## 0.9
 
-### [0.9.1]**(Unreleased)**
+### [0.9.2]**(Unreleased)**
+
+### [0.9.1](../../releases/tag/v0.9.1) - 2025-05-14
 
 #### Fixed
+- fix: `Command.migrate()` programmatically raises KeyError ([#462])
+- fix: `aerich init` removed comments in toml file ([#461])
 - fix: cryptic error message when 'aerich.models' not included. ([#454])
 
+[#462]: https://github.com/tortoise/aerich/pull/462
+[#461]: https://github.com/tortoise/aerich/pull/461
 [#454]: https://github.com/tortoise/aerich/pull/454
 
 ### [0.9.0](../../releases/tag/v0.9.0) - 2025-05-12

--- a/poetry.lock
+++ b/poetry.lock
@@ -1167,14 +1167,14 @@ markers = {dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.6"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7"},
-    {file = "pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a"},
+    {file = "pydantic-2.11.6-py3-none-any.whl", hash = "sha256:a24478d2be1b91b6d3bc9597439f69ed5e87f68ebd285d86f7c7932a084b72e7"},
+    {file = "pydantic-2.11.6.tar.gz", hash = "sha256:12b45cfb4af17e555d3c6283d0b55271865fb0b43cc16dd0d52749dc7abf70e7"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerich"
-version = "0.9.0"
+version = "0.9.1"
 description = "A database migrations tool for Tortoise ORM."
 authors = [{name="long2ice", email="long2ice@gmail.com>"}]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## 0.9.1

### Fixed
- fix: `Command.migrate()` programmatically raises KeyError ([#462])
- fix: `aerich init` removed comments in toml file ([#461])
- fix: cryptic error message when 'aerich.models' not included. ([#454])

[#462]: https://github.com/tortoise/aerich/pull/462
[#461]: https://github.com/tortoise/aerich/pull/461
[#454]: https://github.com/tortoise/aerich/pull/454