### PR TITLE
fix: pgvector data types cause errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:latest
+        image: ankane/pgvector:latest
         ports:
           - 5432:5432
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 #### Changed
 - refactor: use dataclass instead of pydantic for inspectdb ([#466])
 
+#### Fixed
+- fix: pgvector data types cause errors ([#468])
+
+[#468]: https://github.com/tortoise/aerich/pull/468
 [#466]: https://github.com/tortoise/aerich/pull/466
 
 ### [0.9.1](../../releases/tag/v0.9.1) - 2025-05-14

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ _lint: _build
 lint: deps _lint
 
 test: deps
-	$(py_warn) TEST_DB=sqlite://:memory: pytest
+	$(py_warn) pytest $(pytest_opts)
 
 test_sqlite:
-	$(py_warn) TEST_DB=sqlite://:memory: pytest
+	$(py_warn) TEST_DB=sqlite://:memory: pytest $(pytest_opts)
 
 test_mysql:
 	$(py_warn) TEST_DB="mysql://root:$(MYSQL_PASS)@$(MYSQL_HOST):$(MYSQL_PORT)/test_\{\}" pytest -vv -s

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -150,10 +150,12 @@ class Command(AbstractAsyncContextManager):
         tortoise_config: dict,
         app: str = "models",
         location: str = "./migrations",
+        inspectdb_fields: dict[str, str] | None = None,
     ) -> None:
         self.tortoise_config = tortoise_config
         self.app = app
         self.location = location
+        self._inspectdb_fields = inspectdb_fields
         Migrate.app = app
 
     async def init(self) -> None:
@@ -265,6 +267,8 @@ class Command(AbstractAsyncContextManager):
         else:
             raise NotImplementedError(f"{dialect} is not supported")
         inspect = cls(connection, tables)
+        if self._inspectdb_fields:
+            inspect._special_fields = self._inspectdb_fields
         return await inspect.inspect()
 
     @overload

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -290,12 +290,14 @@ class Command(AbstractAsyncContextManager):
         except NotInitedError as e:
             raise NotInitedError("You have to call .init() first before migrate") from e
 
-    async def init_db(self, safe: bool) -> None:
+    async def init_db(self, safe: bool, pre_sql: str | None = None) -> None:
         location = self.location
         app = self.app
 
         await Tortoise.init(config=self.tortoise_config)
         connection = get_app_connection(self.tortoise_config, app)
+        if pre_sql:
+            await connection.execute_script(pre_sql)
 
         dirname = Path(location, app)
         if not dirname.exists():

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -75,11 +75,12 @@ async def cli(ctx: Context, config: str, app: str) -> None:
             tool = cast("dict[str, str]", doc["tool"]["aerich"])
             location = tool["location"]
             tortoise_orm = tool["tortoise_orm"]
-            src_folder = tool.get("src_folder", CONFIG_DEFAULT_VALUES["src_folder"])
         except KeyError as e:
             raise UsageError(
                 "You need run `aerich init` again when upgrading to aerich 0.6.0+."
             ) from e
+        else:
+            src_folder = tool.get("src_folder", CONFIG_DEFAULT_VALUES["src_folder"])
         add_src_path(src_folder)
         tortoise_config = get_tortoise_config(ctx, tortoise_orm)
         if not app:
@@ -89,6 +90,8 @@ async def cli(ctx: Context, config: str, app: str) -> None:
                 raise UsageError('Config must define "apps" section') from None
             app = list(apps_config.keys())[0]
         command = Command(tortoise_config=tortoise_config, app=app, location=location)
+        if inspectdb_fields := tool.get("inspectdb"):
+            command._inspectdb_fields = cast(dict[str, str], inspectdb_fields)
         ctx.obj["command"] = command
         if invoked_subcommand == "init-db":
             _check_aerich_models_included(tortoise_config)

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -334,13 +334,14 @@ async def init(ctx: Context, tortoise_orm: str, location: str, src_folder: str) 
     help="Create tables only when they do not already exist.",
     show_default=True,
 )
+@click.option("--pre", required=False, help="SQL to execute before generating schemas.")
 @click.pass_context
-async def init_db(ctx: Context, safe: bool) -> None:
+async def init_db(ctx: Context, safe: bool, pre: str) -> None:
     command = ctx.obj["command"]
     app = command.app
     dirname = Path(command.location, app)
     try:
-        await command.init_db(safe)
+        await command.init_db(safe, pre)
         click.secho(f"Success creating app migration folder {dirname}", fg=Color.green)
         click.secho(f'Success generating initial migration file for app "{app}"', fg=Color.green)
     except FileExistsError:

--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Callable, TypedDict
 
 from tortoise import BaseDBAsyncClient
+
+from aerich.exceptions import NotSupportError
 
 
 class ColumnInfoDict(TypedDict):
@@ -99,11 +102,17 @@ class Column:
 class Inspect:
     _table_template = "class {table}(Model):\n"
 
-    def __init__(self, conn: BaseDBAsyncClient, tables: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        conn: BaseDBAsyncClient,
+        tables: list[str] | None = None,
+        special_fields: dict[str, str] | None = None,
+    ) -> None:
         self.conn = conn
         with contextlib.suppress(AttributeError):
             self.database = conn.database  # type:ignore[attr-defined]
         self.tables = tables
+        self._special_fields = special_fields
 
     @property
     def field_map(self) -> FieldMapDict:
@@ -112,16 +121,33 @@ class Inspect:
     async def inspect(self) -> str:
         if not self.tables:
             self.tables = await self.get_all_tables()
-        result = "from tortoise import Model, fields\n\n\n"
+        imports = ["from tortoise import Model, fields"]
         tables = []
         for table in self.tables:
             columns = await self.get_columns(table)
             fields = []
             model = self._table_template.format(table=table.title().replace("_", ""))
             for column in columns:
-                field = self.field_map[column.data_type](**column.translate())
+                try:
+                    trans_func = self.field_map[column.data_type]
+                except KeyError as e:
+                    if not self._special_fields or column.data_type not in self._special_fields:
+                        raise NotSupportError(
+                            f"Can't translate {column.data_type=} to be tortoise field"
+                        ) from e
+                    field_class = self._special_fields[column.data_type]
+                    if "." in field_class:  # e.g.: tortoise.contrib.mysql.fields.GeometryField
+                        module, field_class = field_class.rsplit(".", 1)
+                        imports.append(f"from {module} import {field_class}")
+                        trans_func = partial(
+                            self.get_field_string, field_class, is_normal_field=False
+                        )
+                    else:
+                        trans_func = partial(self.get_field_string, field_class)
+                field = trans_func(**column.translate())
                 fields.append("    " + field)
             tables.append(model + "\n".join(fields))
+        result = "\n".join(imports) + "\n\n"
         return result + "\n\n\n".join(tables)
 
     async def get_columns(self, table: str) -> list[Column]:
@@ -132,11 +158,16 @@ class Inspect:
 
     @staticmethod
     def get_field_string(
-        field_class: str, arguments: str = "{null}{default}{comment}", **kwargs
+        field_class: str,
+        arguments: str = "{null}{default}{comment}",
+        is_normal_field: bool = True,
+        **kwargs,
     ) -> str:
         name = kwargs["name"]
         field_params = arguments.format(**kwargs).strip().rstrip(",")
-        return f"{name} = fields.{field_class}({field_params})"
+        if is_normal_field:
+            field_class = "fields." + field_class
+        return f"{name} = {field_class}({field_params})"
 
     @classmethod
     def decimal_field(cls, **kwargs) -> str:

--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -35,6 +35,31 @@ class Column:
     decimal_places: int | None = None
     max_digits: int | None = None
 
+    @staticmethod
+    def trans_default(value: str, data_type: str, extra: str | None) -> str:
+        if data_type in ("tinyint", "INT"):
+            default = f"default={'True' if value == '1' else 'False'}, "
+        elif data_type == "bool":
+            default = f"default={'True' if value == 'true' else 'False'}, "
+        elif data_type in ("datetime", "timestamptz", "TIMESTAMP"):
+            if value == "CURRENT_TIMESTAMP":
+                if extra == "DEFAULT_GENERATED on update CURRENT_TIMESTAMP":
+                    default = "auto_now=True, "
+                else:
+                    default = "auto_now_add=True, "
+            else:
+                default = ""
+        else:
+            if "::" in value:
+                default = f"default={value.split('::')[0]}, "
+            elif value.endswith("()"):
+                default = ""
+            elif value == "":
+                default = 'default=""'
+            else:
+                default = f"default={value}, "
+        return default
+
     def translate(self) -> ColumnInfoDict:
         comment = default = length = index = null = pk = ""
         if self.pk:
@@ -44,6 +69,8 @@ class Column:
                 index = "unique=True, "
             elif self.index:
                 index = "db_index=True, "
+            if self.default is not None:
+                default = self.trans_default(self.default, self.data_type, self.extra)
         if self.data_type in ("varchar", "VARCHAR"):
             length = f"max_length={self.length}, "
         elif self.data_type in ("decimal", "numeric"):
@@ -56,27 +83,6 @@ class Column:
                 length = ", ".join(length_parts) + ", "
         if self.null:
             null = "null=True, "
-        if self.default is not None and not self.pk:
-            if self.data_type in ("tinyint", "INT"):
-                default = f"default={'True' if self.default == '1' else 'False'}, "
-            elif self.data_type == "bool":
-                default = f"default={'True' if self.default == 'true' else 'False'}, "
-            elif self.data_type in ("datetime", "timestamptz", "TIMESTAMP"):
-                if self.default == "CURRENT_TIMESTAMP":
-                    if self.extra == "DEFAULT_GENERATED on update CURRENT_TIMESTAMP":
-                        default = "auto_now=True, "
-                    else:
-                        default = "auto_now_add=True, "
-            else:
-                if "::" in self.default:
-                    default = f"default={self.default.split('::')[0]}, "
-                elif self.default.endswith("()"):
-                    default = ""
-                elif self.default == "":
-                    default = 'default=""'
-                else:
-                    default = f"default={self.default}, "
-
         if self.comment:
             comment = f"description='{self.comment}', "
         return {

--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -136,14 +136,15 @@ class Inspect:
                             f"Can't translate {column.data_type=} to be tortoise field"
                         ) from e
                     field_class = self._special_fields[column.data_type]
+                    is_normal_field = True
                     if "." in field_class:  # e.g.: tortoise.contrib.mysql.fields.GeometryField
                         module, field_class = field_class.rsplit(".", 1)
-                        imports.append(f"from {module} import {field_class}")
-                        trans_func = partial(
-                            self.get_field_string, field_class, is_normal_field=False
-                        )
-                    else:
-                        trans_func = partial(self.get_field_string, field_class)
+                        if module != "fields":
+                            imports.append(f"from {module} import {field_class}")
+                            is_normal_field = False
+                    trans_func = partial(
+                        self.get_field_string, field_class, is_normal_field=is_normal_field
+                    )
                 field = trans_func(**column.translate())
                 fields.append("    " + field)
             tables.append(model + "\n".join(fields))

--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import contextlib
+from dataclasses import dataclass
 from typing import Any, Callable, TypedDict
 
-from pydantic import BaseModel
 from tortoise import BaseDBAsyncClient
 
 
@@ -20,15 +20,16 @@ class ColumnInfoDict(TypedDict):
 FieldMapDict = dict[str, Callable[..., str]]
 
 
-class Column(BaseModel):
+@dataclass
+class Column:
     name: str
     data_type: str
     null: bool
     default: Any
-    comment: str | None = None
     pk: bool
     unique: bool
     index: bool
+    comment: str | None = None
     length: int | None = None
     extra: str | None = None
     decimal_places: int | None = None

--- a/aerich/inspectdb/__init__.py
+++ b/aerich/inspectdb/__init__.py
@@ -58,7 +58,7 @@ class Column:
             elif value.endswith("()"):
                 default = ""
             elif value == "":
-                default = 'default=""'
+                default = 'default="", '
             else:
                 default = f"default={value}, "
         return default

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -43,19 +43,19 @@ def add_src_path(path: str) -> str:
     return path
 
 
-def get_app_connection_name(config, app_name: str) -> str:
+def get_app_connection_name(config: dict, app_name: str) -> str:
     """
     get connection name
     :param config:
     :param app_name:
     :return: the default connection name (Usally it is 'default')
     """
-    if app := config.get("apps").get(app_name):
+    if app := config["apps"].get(app_name):
         return app.get("default_connection", "default")
     raise BadOptionUsage(option_name="--app", message=f"Can't get app named {app_name!r}")
 
 
-def get_app_connection(config, app) -> BaseDBAsyncClient:
+def get_app_connection(config: dict, app: str) -> BaseDBAsyncClient:
     """
     get connection client
     :param config:

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,7 @@ version = "0.21.0"
 description = "asyncio bridge to the standard sqlite3 module"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0"},
     {file = "aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3"},
@@ -61,19 +61,6 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
 test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1) ; python_version >= \"3.10\"", "uvloop (>=0.21) ; platform_python_implementation == \"CPython\" and platform_system != \"Windows\" and python_version < \"3.14\""]
 trio = ["trio (>=0.26.1)"]
-
-[[package]]
-name = "async-timeout"
-version = "5.0.1"
-description = "Timeout context manager for asyncio programs"
-optional = true
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"asyncpg\" and python_version < \"3.11.0\""
-files = [
-    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
-    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
-]
 
 [[package]]
 name = "asyncclick"
@@ -163,10 +150,9 @@ files = [
 name = "asyncpg"
 version = "0.30.0"
 description = "An asyncio PostgreSQL driver"
-optional = true
+optional = false
 python-versions = ">=3.8.0"
-groups = ["main"]
-markers = "extra == \"asyncpg\""
+groups = ["main", "test"]
 files = [
     {file = "asyncpg-0.30.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfb4dd5ae0699bad2b233672c8fc5ccbd9ad24b89afded02341786887e37927e"},
     {file = "asyncpg-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc1f62c792752a49f88b7e6f774c26077091b44caceb1983509edc18a2222ec0"},
@@ -218,9 +204,7 @@ files = [
     {file = "asyncpg-0.30.0-cp39-cp39-win_amd64.whl", hash = "sha256:8b684a3c858a83cd876f05958823b68e8d14ec01bb0c0d14a6704c5bf9711773"},
     {file = "asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851"},
 ]
-
-[package.dependencies]
-async-timeout = {version = ">=4.0.3", markers = "python_version < \"3.11.0\""}
+markers = {main = "extra == \"asyncpg\"", test = "python_version >= \"3.11\" and python_version < \"4.0\" or extra == \"asyncpg\""}
 
 [package.extras]
 docs = ["Sphinx (>=8.1.3,<8.2.0)", "sphinx-rtd-theme (>=1.2.2)"]
@@ -680,7 +664,7 @@ version = "2.1.0"
 description = "Simple module to parse ISO 8601 dates"
 optional = false
 python-versions = ">=3.7,<4.0"
-groups = ["main"]
+groups = ["main", "test"]
 markers = "python_version < \"4.0\""
 files = [
     {file = "iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242"},
@@ -1175,7 +1159,7 @@ version = "0.6.1"
 description = "Forked from pypika and streamline just for tortoise-orm"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 markers = "python_version < \"4.0\""
 files = [
     {file = "pypika_tortoise-0.6.1-py3-none-any.whl", hash = "sha256:da15886f37b347e71f0869f9e4ee2f9259e6bb57455b45299c6c23d7927cbb6e"},
@@ -1270,7 +1254,7 @@ version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -1612,7 +1596,7 @@ version = "0.25.1"
 description = "Easy async ORM for python, built with relations in mind"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "tortoise_orm-0.25.1-py3-none-any.whl", hash = "sha256:df0ef7e06eb0650a7e5074399a51ee6e532043308c612db2cac3882486a3fd9f"},
     {file = "tortoise_orm-0.25.1.tar.gz", hash = "sha256:4d5bfd13d5750935ffe636a6b25597c5c8f51c47e5b72d7509d712eda1a239fe"},
@@ -1620,6 +1604,7 @@ files = [
 
 [package.dependencies]
 aiosqlite = ">=0.16.0,<1.0.0"
+asyncpg = {version = "*", optional = true, markers = "extra == \"asyncpg\""}
 iso8601 = {version = ">=2.1.0,<3.0.0", markers = "python_version < \"4.0\""}
 pypika-tortoise = {version = ">=0.6.1,<1.0.0", markers = "python_version < \"4.0\""}
 pytz = "*"
@@ -1631,6 +1616,22 @@ asyncmy = ["asyncmy (>=0.2.8,<1.0.0) ; python_version < \"4.0\""]
 asyncodbc = ["asyncodbc (>=0.1.1,<1.0.0) ; python_version < \"4.0\""]
 asyncpg = ["asyncpg"]
 psycopg = ["psycopg[binary,pool] (>=3.0.12,<4.0.0)"]
+
+[[package]]
+name = "tortoise-vector"
+version = "0.1.4"
+description = "pgvector implementation for Tortoise-ORM"
+optional = false
+python-versions = ">=3.11,<4.0"
+groups = ["test"]
+markers = "python_version >= \"3.11\" and python_version < \"4.0\""
+files = [
+    {file = "tortoise_vector-0.1.4-py3-none-any.whl", hash = "sha256:d277ea0bec85858d559790e11d2779135824935f3bb6e81275744048f87e34d0"},
+    {file = "tortoise_vector-0.1.4.tar.gz", hash = "sha256:6d0cf318252042c2e6ad3d9d7c09ff4e207f37bf6b24414b34561dfd5d000c26"},
+]
+
+[package.dependencies]
+tortoise-orm = {version = ">=0.23", extras = ["asyncpg"]}
 
 [[package]]
 name = "twine"
@@ -1670,7 +1671,6 @@ files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
     {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
 ]
-markers = {test = "python_version < \"3.11\""}
 
 [[package]]
 name = "tzdata"
@@ -1734,4 +1734,4 @@ toml = ["tomli-w", "tomlkit"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "71ac9959de568607df828a42f8fae91ccac4e1090257b8cfa20a6b0d4129de3d"
+content-hash = "e8a51d8e81a86b7e8e27dd08d4f6ba650d7dbb45108cbce3a038401fedb7de7e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,18 +40,6 @@ dev = ["attribution (==1.7.1)", "black (==24.3.0)", "build (>=1.2)", "coverage[t
 docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.1)"]
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-description = "Reusable constraint types to use with typing.Annotated"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
-]
-
-[[package]]
 name = "anyio"
 version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -579,22 +567,6 @@ files = [
     {file = "docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2"},
     {file = "docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"},
 ]
-
-[[package]]
-name = "eval-type-backport"
-version = "0.2.2"
-description = "Like `typing._eval_type`, but lets older Python versions use newer typing features."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "python_version == \"3.9\""
-files = [
-    {file = "eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a"},
-    {file = "eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1"},
-]
-
-[package.extras]
-tests = ["pytest"]
 
 [[package]]
 name = "exceptiongroup"
@@ -1166,140 +1138,6 @@ files = [
 markers = {dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" or python_full_version > \"3.9.0\" and python_full_version != \"3.9.1\" and platform_python_implementation != \"PyPy\"", test = "python_full_version > \"3.9.0\" and python_full_version != \"3.9.1\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
-name = "pydantic"
-version = "2.11.6"
-description = "Data validation using Python type hints"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic-2.11.6-py3-none-any.whl", hash = "sha256:a24478d2be1b91b6d3bc9597439f69ed5e87f68ebd285d86f7c7932a084b72e7"},
-    {file = "pydantic-2.11.6.tar.gz", hash = "sha256:12b45cfb4af17e555d3c6283d0b55271865fb0b43cc16dd0d52749dc7abf70e7"},
-]
-
-[package.dependencies]
-annotated-types = ">=0.6.0"
-pydantic-core = "2.33.2"
-typing-extensions = ">=4.12.2"
-typing-inspection = ">=0.4.0"
-
-[package.extras]
-email = ["email-validator (>=2.0.0)"]
-timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
-
-[[package]]
-name = "pydantic-core"
-version = "2.33.2"
-description = "Core functionality for Pydantic validation and serialization"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22"},
-    {file = "pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab"},
-    {file = "pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2"},
-    {file = "pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9"},
-    {file = "pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5"},
-    {file = "pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9"},
-    {file = "pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c"},
-    {file = "pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb"},
-    {file = "pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039"},
-    {file = "pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27"},
-    {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
-]
-
-[package.dependencies]
-typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1835,21 +1673,6 @@ files = [
 markers = {test = "python_version < \"3.11\""}
 
 [[package]]
-name = "typing-inspection"
-version = "0.4.1"
-description = "Runtime typing introspection tools"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51"},
-    {file = "typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"},
-]
-
-[package.dependencies]
-typing-extensions = ">=4.12.0"
-
-[[package]]
 name = "tzdata"
 version = "2025.2"
 description = "Provider of IANA time zone data"
@@ -1911,4 +1734,4 @@ toml = ["tomli-w", "tomlkit"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "c29b0cde399003eaf9b4e7947c8491a45fab69e3a88865fe6e3e100974bcefdc"
+content-hash = "71ac9959de568607df828a42f8fae91ccac4e1090257b8cfa20a6b0d4129de3d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -63,6 +63,19 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
+    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
+]
+
+[[package]]
 name = "asyncclick"
 version = "8.1.8"
 description = "Composable command line interface toolkit, "
@@ -1734,4 +1747,4 @@ toml = ["tomli-w", "tomlkit"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "e8a51d8e81a86b7e8e27dd08d4f6ba650d7dbb45108cbce3a038401fedb7de7e"
+content-hash = "da27cfd16bba1a83dcb8624c41bc500129321f80e64c654ab4fefb5f723d7aee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ pytest-xdist = "^3.6.0"
 pytest-asyncio = "^0.21.2"
 # required for sha256_password by asyncmy
 cryptography = {version="*", python=">3.9.0,<3.9.1 || >3.9.1"}
+tortoise-vector = {version="^0.1.4", python=">=3.11,<4.0"}
 
 [tool.aerich]
 tortoise_orm = "conftest.tortoise_orm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ include = ["CHANGELOG.md", "LICENSE", "README.md"]
 requires-python = ">=3.9"
 dependencies = [
   "tortoise-orm (>=0.24.0,<1.0.0)",
-  "pydantic (>=2.0.2,!=2.1.0,!=2.7.0,<3.0.0)",
   "dictdiffer (>=0.9.0,<1.0.0)",
   "asyncclick (>=8.1.7,<9.0.0)",
-  "eval-type-backport (>=0.2.2,<1.0.0); python_version < '3.10'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pytest-asyncio = "^0.21.2"
 # required for sha256_password by asyncmy
 cryptography = {version="*", python=">3.9.0,<3.9.1 || >3.9.1"}
 tortoise-vector = {version="^0.1.4", python=">=3.11,<4.0"}
+async-timeout = {version="^5.0.1", python="<3.11"}
 
 [tool.aerich]
 tortoise_orm = "conftest.tortoise_orm"

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -5,9 +5,13 @@ import shlex
 import shutil
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
+from typing import Callable, Literal
 
 from tortoise import Tortoise, generate_schema_for_client
+from tortoise.contrib import test
+from tortoise.contrib.test.condition import In, NotEQ
 from tortoise.exceptions import DBConnectionError, OperationalError
 
 if sys.version_info >= (3, 11):
@@ -88,7 +92,30 @@ def run_shell(command: str, capture_output=True, **kw) -> str:
     return r.stdout.decode()
 
 
-def prepare_py_files(asset_name: str, assets: Path = ASSETS) -> None:
+def prepare_py_files(asset_name: str, assets: Path = ASSETS, suffix: str = ".py") -> None:
     asset_dir = assets / asset_name
-    for file in asset_dir.glob("*.py"):
+    for file in asset_dir.glob(f"*{suffix}"):
         shutil.copy(file, file.name)
+
+
+def skip_dialect(name: Literal["sqlite", "mysql", "postgres"]) -> Callable:
+    return test.requireCapability("default", dialect=NotEQ(name))
+
+
+def requires_dialect(
+    name: Literal["sqlite", "mysql", "postgres"],
+    *more: Literal["sqlite", "mysql", "postgres"],
+) -> Callable:
+    if more and set(more) != {name}:
+        return test.requireCapability("default", dialect=In(name, *more))
+    return test.requireCapability("default", dialect=name)
+
+
+@contextlib.contextmanager
+def tmp_daily_db(env_name="AERICH_DONT_DROP_TMP_DB") -> Generator[None]:
+    run_shell("python db.py create", capture_output=False)
+    try:
+        yield
+    finally:
+        if not os.getenv(env_name):
+            run_shell("python db.py drop", capture_output=False)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -81,15 +81,17 @@ ASSETS = Path(__file__).parent / "assets"
 WINDOWS = platform.system() == "Windows"
 
 
-def run_shell(command: str, capture_output=True, **kw) -> str:
+def run_in_subprocess(command: str, capture_output=True, **kw) -> tuple[bool, str]:
     if WINDOWS and command.startswith("aerich "):
         command = "python -m " + command
-    r = subprocess.run(shlex.split(command), capture_output=capture_output)
-    if r.returncode != 0 and r.stderr:
-        return r.stderr.decode()
-    if not r.stdout:
-        return ""
-    return r.stdout.decode()
+    r = subprocess.run(shlex.split(command), capture_output=capture_output, encoding="utf-8")
+    ok = r.returncode == 0
+    out = (r.stdout or "") if ok else (r.stderr or r.stdout or "")
+    return ok, out
+
+
+def run_shell(command: str, capture_output=True, **kw) -> str:
+    return run_in_subprocess(command, capture_output, **kw)[1]
 
 
 def prepare_py_files(asset_name: str, assets: Path = ASSETS, suffix: str = ".py") -> None:
@@ -113,9 +115,13 @@ def requires_dialect(
 
 @contextlib.contextmanager
 def tmp_daily_db(env_name="AERICH_DONT_DROP_TMP_DB") -> Generator[None]:
-    run_shell("python db.py create", capture_output=False)
+    ok, out = run_in_subprocess("python db.py create")
+    if not ok:
+        raise OperationalError(out)
     try:
         yield
     finally:
         if not os.getenv(env_name):
-            run_shell("python db.py drop", capture_output=False)
+            ok, out = run_in_subprocess("python db.py drop")
+            if not ok:
+                raise OperationalError(out)

--- a/tests/assets/postgres_vector/db.py
+++ b/tests/assets/postgres_vector/db.py
@@ -1,0 +1,28 @@
+import asyncclick as click
+from settings import TORTOISE_ORM
+
+from tests._utils import drop_db, init_db
+
+
+@click.group()
+def cli(): ...
+
+
+@cli.command()
+async def create():
+    await init_db(TORTOISE_ORM, False)
+    click.echo(f"Success to create databases for {TORTOISE_ORM['connections']}")
+
+
+@cli.command()
+async def drop():
+    await drop_db(TORTOISE_ORM)
+    click.echo(f"Dropped databases for {TORTOISE_ORM['connections']}")
+
+
+def main():
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/assets/postgres_vector/models.py
+++ b/tests/assets/postgres_vector/models.py
@@ -1,0 +1,7 @@
+from tortoise import Model, fields
+from tortoise.contrib.postgres.fields import TSVectorField
+
+
+class Foo(Model):
+    a = fields.IntField()
+    b = TSVectorField()

--- a/tests/assets/postgres_vector/models.py
+++ b/tests/assets/postgres_vector/models.py
@@ -1,7 +1,9 @@
 from tortoise import Model, fields
 from tortoise.contrib.postgres.fields import TSVectorField
+from tortoise_vector.field import VectorField
 
 
 class Foo(Model):
     a = fields.IntField()
     b = TSVectorField()
+    c = VectorField(1536)

--- a/tests/assets/postgres_vector/pyproject.toml
+++ b/tests/assets/postgres_vector/pyproject.toml
@@ -5,3 +5,4 @@ src_folder = "./."
 
 [tool.aerich.inspectdb]
 tsvector = "tortoise.contrib.postgres.fields.TSVectorField"
+vector = "tortoise_vector.field.VectorField"

--- a/tests/assets/postgres_vector/pyproject.toml
+++ b/tests/assets/postgres_vector/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.aerich]
+tortoise_orm = "settings.TORTOISE_ORM"
+location = "./migrations"
+src_folder = "./."
+
+[tool.aerich.inspectdb]
+tsvector = "tortoise.contrib.postgres.fields.TSVectorField"

--- a/tests/assets/postgres_vector/settings.py
+++ b/tests/assets/postgres_vector/settings.py
@@ -1,0 +1,19 @@
+import os
+from datetime import date
+
+from tortoise.contrib.test import MEMORY_SQLITE
+
+DB_URL = (
+    _u.replace("\\{\\}", f"aerich_postgres_vector_{date.today():%Y%m%d}")
+    if (_u := os.getenv("TEST_DB"))
+    else MEMORY_SQLITE
+)
+
+TORTOISE_ORM = {
+    "connections": {
+        "default": DB_URL.replace(MEMORY_SQLITE, "sqlite://db.sqlite3"),
+    },
+    "apps": {
+        "models": {"models": ["models", "aerich.models"], "default_connection": "default"},
+    },
+}

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 
-from tests._utils import Dialect, run_shell
+from tests._utils import run_shell, skip_dialect
 
 
 def _append_field(*files: str, name="field_1") -> None:
@@ -15,10 +15,9 @@ def _append_field(*files: str, name="field_1") -> None:
             f.write(os.linesep + field)
 
 
+# TODO: remove skip decorator to test sqlite if alter-column supported
+@skip_dialect("sqlite")
 def test_fake(new_aerich_project):
-    if Dialect.is_sqlite():
-        # TODO: go ahead if sqlite alter-column supported
-        return
     output = run_shell("aerich init -t settings.TORTOISE_ORM")
     assert "Success" in output
     output = run_shell("aerich init-db")

--- a/tests/test_inspectdb.py
+++ b/tests/test_inspectdb.py
@@ -7,7 +7,7 @@ from tests._utils import (
     Dialect,
     prepare_py_files,
     requires_dialect,
-    run_shell,
+    run_in_subprocess,
     skip_dialect,
     tmp_daily_db,
 )
@@ -16,9 +16,14 @@ from tests._utils import (
 # TODO: remove skip decorator to test sqlite after #384 fixed
 @skip_dialect("sqlite")
 def test_inspect(new_aerich_project):
-    run_shell("aerich init -t settings.TORTOISE_ORM")
-    run_shell("aerich init-db")
-    ret = run_shell("aerich inspectdb -t product")
+    ok, out = run_in_subprocess("aerich init -t settings.TORTOISE_ORM")
+    if not ok:
+        print("Failed to init:", out)
+    ok, out = run_in_subprocess("aerich init-db")
+    if not ok:
+        print("ERROR init-db:", out)
+    ok, ret = run_in_subprocess("aerich inspectdb -t product")
+    assert ok, ret
     assert ret.startswith("from tortoise import Model, fields")
     assert "primary_key=True" in ret
     assert "fields.DatetimeField" in ret
@@ -33,8 +38,11 @@ def test_inspect(new_aerich_project):
 def test_inspect_vector(tmp_work_dir: Path):
     prepare_py_files("postgres_vector", suffix=".*")
     with tmp_daily_db():
-        run_shell("aerich init-db")
-        ret = run_shell("aerich inspectdb -t foo")
+        ok, out = run_in_subprocess("aerich init-db --pre='CREATE EXTENSION IF NOT EXISTS vector'")
+        if not ok:
+            print("ERROR init-db:", out)
+        ok, ret = run_in_subprocess("aerich inspectdb -t foo")
+    assert ok, ret
     expected = """
 from tortoise import Model, fields
 from tortoise.contrib.postgres.fields import TSVectorField

--- a/tests/test_inspectdb.py
+++ b/tests/test_inspectdb.py
@@ -1,10 +1,21 @@
-from tests._utils import Dialect, run_shell
+import sys
+from pathlib import Path
+
+from tortoise.contrib import test
+
+from tests._utils import (
+    Dialect,
+    prepare_py_files,
+    requires_dialect,
+    run_shell,
+    skip_dialect,
+    tmp_daily_db,
+)
 
 
+# TODO: remove skip decorator to test sqlite after #384 fixed
+@skip_dialect("sqlite")
 def test_inspect(new_aerich_project):
-    if Dialect.is_sqlite():
-        # TODO: test sqlite after #384 fixed
-        return
     run_shell("aerich init -t settings.TORTOISE_ORM")
     run_shell("aerich init-db")
     ret = run_shell("aerich inspectdb -t product")
@@ -15,3 +26,24 @@ def test_inspect(new_aerich_project):
     assert "fields.UUIDField" in ret
     if Dialect.is_mysql():
         assert "db_index=True" in ret
+
+
+@requires_dialect("postgres")
+@test.skipIf(sys.version_info < (3, 11), "tortoise-vector requires python>=3.11")
+def test_inspect_vector(tmp_work_dir: Path):
+    prepare_py_files("postgres_vector", suffix=".*")
+    with tmp_daily_db():
+        run_shell("aerich init-db")
+        ret = run_shell("aerich inspectdb -t foo")
+    expected = """
+from tortoise import Model, fields
+from tortoise.contrib.postgres.fields import TSVectorField
+from tortoise_vector.field import VectorField
+
+class Foo(Model):
+    id = fields.IntField(primary_key=True)
+    a = fields.IntField()
+    b = TSVectorField()
+    c = VectorField()
+    """
+    assert expected.strip() in ret

--- a/tests/test_python_m.py
+++ b/tests/test_python_m.py
@@ -2,7 +2,7 @@ import subprocess  # nosec
 from pathlib import Path
 
 from aerich.version import __version__
-from tests._utils import chdir, run_shell
+from tests._utils import run_shell
 
 
 def test_python_m_aerich():
@@ -10,8 +10,7 @@ def test_python_m_aerich():
 
 
 def test_poetry_add(tmp_work_dir: Path):
+    run_shell('poetry init --no-interaction --python=">=3.9"')
     package = Path(__file__).parent.resolve().parent
-    subprocess.run(["poetry", "new", "foo"])  # nosec
-    with chdir("foo"):
-        r = subprocess.run(["poetry", "add", package])  # nosec
-        assert r.returncode == 0
+    r = subprocess.run(["poetry", "add", package])  # nosec
+    assert r.returncode == 0

--- a/tests/test_remove_unique_constraint.py
+++ b/tests/test_remove_unique_constraint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from tests._utils import Dialect, run_shell
+from tests._utils import run_shell, skip_dialect
 
 
 def _update_model(from_file: str) -> None:
@@ -11,10 +11,9 @@ def _update_model(from_file: str) -> None:
     shutil.copy(abspath, "models.py")
 
 
+# TODO: remove skip decorator to test sqlite if alter-column supported
+@skip_dialect("sqlite")
 def test_remove_unique_constraint(tmp_aerich_project):
-    if Dialect.is_sqlite():
-        # TODO: go ahead if sqlite alter-column supported
-        return
     output = run_shell("aerich init -t settings.TORTOISE_ORM")
     assert "Success" in output
     output = run_shell("aerich init-db")

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -10,7 +10,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests._utils import Dialect, prepare_py_files
+from tests._utils import Dialect, prepare_py_files, requires_dialect
 
 
 def run_aerich(cmd: str) -> subprocess.CompletedProcess | None:
@@ -54,9 +54,8 @@ def test_close_tortoise_connections_patch(tmp_work_dir: Path) -> None:
         assert r is not None
 
 
+@requires_dialect("sqlite")
 def test_sqlite_migrate_alter_indexed_unique(tmp_work_dir: Path) -> None:
-    if not Dialect.is_sqlite():
-        return
     with prepare_sqlite_project(tmp_work_dir) as (models_py, models_text):
         models_py.write_text(models_text.replace("db_index=False", "db_index=True"))
         run_aerich("aerich init -t settings.TORTOISE_ORM")
@@ -91,9 +90,8 @@ class FooGroup(Model):
 """
 
 
+@requires_dialect("sqlite")
 def test_sqlite_migrate(tmp_work_dir: Path) -> None:
-    if not Dialect.is_sqlite():
-        return
     with prepare_sqlite_project(tmp_work_dir) as (models_py, models_text):
         MODELS = models_text
         run_aerich("aerich init -t settings.TORTOISE_ORM")


### PR DESCRIPTION
# Description
Fixes #465 

To inspectdb 'vector' data type, you have to add tool.aerich.inspectdb section into pyproject.toml
```TOML
[tool.aerich.inspectdb]
vector = "tortoise_vector.field.VectorField"
``` 
After that, when you run `aerich inspectdb` the 'vector' data type will be translated to be 'VectorField' and imported by `from tortoise_vector.field import VectorField`