### PR TITLE
feat: auto add aerich.models

### DIFF
--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -7,7 +7,6 @@ from typing import cast
 
 import asyncclick as click
 from asyncclick import Context, UsageError
-from tortoise.exceptions import ConfigurationError
 
 from aerich import Command
 from aerich._compat import imports_tomlkit, tomllib
@@ -37,25 +36,26 @@ def _patch_context_to_close_tortoise_connections_when_exit() -> None:
 _patch_context_to_close_tortoise_connections_when_exit()
 
 
-def _check_aerich_models_included(tortoise_config: dict, e: Exception | None = None) -> None:
-    all_models = [
-        m for model in tortoise_config.get("apps", {}).values() for m in model.get("models", [])
-    ]
-    if all_models and "aerich.models" not in all_models:
-        raise UsageError(
-            "You have to add 'aerich.models' in the models of your tortoise config"
-        ) from e
+def _check_aerich_models_included(tortoise_config: dict) -> None:
+    # e.g.: tortoise_config = {'apps': {'app_1': {'models': ['models']}}}
+    apps: dict[str, dict[str, list]] = tortoise_config.get("apps", {})
+    app_values: list[dict[str, list[str]]] = list(apps.values())
+    all_models: set[str] = {m for model in app_values for m in model.get("models", [])}
+    if not all_models:
+        return
+    aerich_item = "aerich.models"
+    if aerich_item in all_models:
+        return
+    if len(apps) == 1:
+        # Auto add 'aerich.models' if there is only one app
+        apps[list(apps)[0]]["models"].append(aerich_item)
+        return
+    raise UsageError(f"You have to add {aerich_item!r} in the models of your tortoise config")
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(__version__, "-V", "--version")
-@click.option(
-    "-c",
-    "--config",
-    default="pyproject.toml",
-    show_default=True,
-    help="Config file.",
-)
+@click.option("-c", "--config", default="pyproject.toml", show_default=True, help="Config file.")
 @click.option("--app", required=False, help="Tortoise-ORM app name.")
 @click.pass_context
 async def cli(ctx: Context, config: str, app: str) -> None:
@@ -93,18 +93,13 @@ async def cli(ctx: Context, config: str, app: str) -> None:
         if inspectdb_fields := tool.get("inspectdb"):
             command._inspectdb_fields = cast(dict[str, str], inspectdb_fields)
         ctx.obj["command"] = command
-        if invoked_subcommand == "init-db":
-            _check_aerich_models_included(tortoise_config)
-        else:
+        _check_aerich_models_included(tortoise_config)
+        if invoked_subcommand != "init-db":
             if not Path(location, app).exists():
                 raise UsageError(
                     "You need to run `aerich init-db` first to initialize the database.", ctx=ctx
                 )
-            try:
-                await command.init()
-            except ConfigurationError as e:
-                _check_aerich_models_included(tortoise_config, e)
-                raise e
+            await command.init()
 
 
 @cli.command(help="Generate a migration file for the current state of the models.")

--- a/tests/assets/missing_aerich_models/other_models.py
+++ b/tests/assets/missing_aerich_models/other_models.py
@@ -1,0 +1,5 @@
+from tortoise import Model, fields
+
+
+class Sth(Model):
+    a = fields.IntField()

--- a/tests/assets/missing_aerich_models/settings.py
+++ b/tests/assets/missing_aerich_models/settings.py
@@ -21,3 +21,17 @@ TORTOISE_ORM_NO_AERICH_MODELS = {
         "models": {"models": ["models"]},
     },
 }
+TORTOISE_ORM_MULTI_APPS_WITHOUT_AERICH_MODELS = {
+    **TORTOISE_ORM,
+    "apps": {
+        "models": {"models": ["models"]},
+        "other_models": {"models": ["other_models"]},
+    },
+}
+TORTOISE_ORM_MULTI_APPS = {
+    **TORTOISE_ORM,
+    "apps": {
+        "models": {"models": ["models", "aerich.models"]},
+        "other_models": {"models": ["other_models"]},
+    },
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,20 +49,51 @@ def test_migrate_with_same_version_file_exists(project_with_unapplied_migrations
     assert "1 passed" in output
 
 
+def test_auto_add_aerich_models(tmp_work_dir: Path) -> None:
+    prepare_py_files("missing_aerich_models")
+    output = run_shell("aerich init -t settings.TORTOISE_ORM_NO_AERICH_MODELS")
+    assert "Success writing aerich config to pyproject.toml" in output
+    output = run_shell("aerich init-db")
+    assert "Success" in output
+    with open("models.py", "a+") as f:
+        f.write("    b = fields.IntField(null=True)\n")
+    output = run_shell("aerich migrate")
+    assert "Success" in output
+    output = run_shell("aerich upgrade")
+    assert "Success" in output
+
+
 def test_missing_aerich_models(tmp_work_dir: Path) -> None:
     prepare_py_files("missing_aerich_models")
-    run_shell("aerich init -t settings.TORTOISE_ORM_NO_AERICH_MODELS", capture_output=False)
+    output = run_shell("aerich init -t settings.TORTOISE_ORM_MULTI_APPS_WITHOUT_AERICH_MODELS")
+    assert "Success writing aerich config to pyproject.toml" in output
     output = run_shell("aerich init-db")
     assert "You have to add 'aerich.models' in the models of your tortoise config" in output
+
+    output = run_shell("aerich init -t settings.TORTOISE_ORM_MULTI_APPS")
+    assert "Success writing aerich config to pyproject.toml" in output
     output = run_shell("aerich migrate")
     assert "need to run `aerich init-db` first" in output
     output = run_shell("aerich upgrade")
     assert "need to run `aerich init-db` first" in output
-    Path("migrations", "models").mkdir()
+
+    output = run_shell("aerich init-db")
+    assert "Success" in output
+    output = run_shell("aerich init -t settings.TORTOISE_ORM_MULTI_APPS_WITHOUT_AERICH_MODELS")
+    assert "Success writing aerich config to pyproject.toml" in output
     output = run_shell("aerich migrate")
     assert "You have to add 'aerich.models' in the models of your tortoise config" in output
     output = run_shell("aerich upgrade")
     assert "You have to add 'aerich.models' in the models of your tortoise config" in output
+
+    output = run_shell("aerich init -t settings.TORTOISE_ORM_MULTI_APPS")
+    assert "Success" in output
+    with open("models.py", "a+") as f:
+        f.write("    b = fields.IntField(null=True)\n")
+    output = run_shell("aerich migrate")
+    assert "Success" in output
+    output = run_shell("aerich upgrade")
+    assert "Success" in output
 
 
 def test_aerich_init(tmp_work_dir: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from aerich._compat import tomllib
-from tests._utils import prepare_py_files, run_shell
+from tests._utils import prepare_py_files, requires_dialect, run_shell
 
 
 @pytest.fixture
@@ -49,7 +49,9 @@ def test_migrate_with_same_version_file_exists(project_with_unapplied_migrations
     assert "1 passed" in output
 
 
-def test_auto_add_aerich_models(tmp_work_dir: Path) -> None:
+@requires_dialect("sqlite")
+@pytest.mark.usefixtures("tmp_work_dir")
+def test_auto_add_aerich_models() -> None:
     prepare_py_files("missing_aerich_models")
     output = run_shell("aerich init -t settings.TORTOISE_ORM_NO_AERICH_MODELS")
     assert "Success writing aerich config to pyproject.toml" in output
@@ -63,7 +65,9 @@ def test_auto_add_aerich_models(tmp_work_dir: Path) -> None:
     assert "Success" in output
 
 
-def test_missing_aerich_models(tmp_work_dir: Path) -> None:
+@requires_dialect("sqlite")
+@pytest.mark.usefixtures("tmp_work_dir")
+def test_missing_aerich_models() -> None:
     prepare_py_files("missing_aerich_models")
     output = run_shell("aerich init -t settings.TORTOISE_ORM_MULTI_APPS_WITHOUT_AERICH_MODELS")
     assert "Success writing aerich config to pyproject.toml" in output
@@ -96,7 +100,8 @@ def test_missing_aerich_models(tmp_work_dir: Path) -> None:
     assert "Success" in output
 
 
-def test_aerich_init(tmp_work_dir: Path) -> None:
+@pytest.mark.usefixtures("tmp_work_dir")
+def test_aerich_init() -> None:
     prepare_py_files("missing_aerich_models")
     toml_file = Path("pyproject.toml")
     # init without pyproject.toml


### PR DESCRIPTION
# Description

If tortoise config has only one app, e.g.:
```py
TORTOISE_ORM = {
    'connections': {'default': 'sqlite://db.sqlite3'},
    'apps': {'models': {'models': ['models']}}
}
```
run `aerich <command>` will auto append 'aerich.models' to `TORTOISE_ORM['apps']['models']['models']`

Elif tortoise config has multi apps, e.g:
```py
TORTOISE_ORM = {
    'connections': {'default': 'sqlite://db.sqlite3'},
    'apps': {
        'models': {'models': ['models']},
        'second_models': {'models': ['seconds_models']}
    }
}
```
run any aerich command (except init) will raises UsageError