### PR TITLE
refactor: use `ctx.with_async_resource` instead of magic patch `Context.__aexit__`

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -188,6 +188,7 @@ class Command(AbstractAsyncContextManager):
 
     @staticmethod
     async def aclose() -> None:
+        """Close tortoise connections if it was inited"""
         if Tortoise._inited:
             await connections.close_all()
 

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pkgutil
 import platform
+import warnings
 from collections.abc import Generator
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
@@ -176,10 +177,20 @@ class Command(AbstractAsyncContextManager):
         return _self().__await__()
 
     async def close(self) -> None:
-        await connections.close_all()
+        warnings.warn(
+            "`Command.close()` is deprecated, please use Command.aclose() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        await self.aclose()
+
+    @staticmethod
+    async def aclose() -> None:
+        if Tortoise._inited:
+            await connections.close_all()
 
     async def __aexit__(self, *args, **kw) -> None:
-        await self.close()
+        await self.aclose()
 
     async def _upgrade(
         self,

--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -161,12 +161,14 @@ class Command(AbstractAsyncContextManager):
         self.location = location
         self._inspectdb_fields = inspectdb_fields
         Migrate.app = app
+        self._init_when_aenter = True
 
     async def init(self) -> None:
         await Migrate.init(self.tortoise_config, self.app, self.location)
 
     async def __aenter__(self) -> Command:
-        await self.init()
+        if self._init_when_aenter:
+            await self.init()
         return self
 
     def __await__(self) -> Generator[Any, None, Command]:

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -21,15 +21,16 @@ CONFIG_DEFAULT_VALUES = {
 
 
 def _patch_context_to_close_tortoise_connections_when_exit() -> None:
-    if not hasattr(Context, "_patched"):
-        origin_aexit = Context.__aexit__
+    if not hasattr(Context, attr := "_tortoise_patched"):
+        func_name = "__aexit__"
+        origin_func = getattr(Context, func_name)
 
-        async def aexit(*args, **kw) -> None:
-            await origin_aexit(*args, **kw)
+        async def patched(*args, **kw) -> None:
+            await origin_func(*args, **kw)
             await Command.aclose()
 
-        Context.__aexit__ = aexit  # type:ignore[method-assign]
-        Context._patched = True  # type:ignore[attr-defined]
+        setattr(Context, func_name, patched)
+        setattr(Context, attr, True)
 
 
 _patch_context_to_close_tortoise_connections_when_exit()

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -76,7 +76,9 @@ async def cli(ctx: Context, config: str, app: str) -> None:
         command = Command(tortoise_config=tortoise_config, app=app, location=location)
         if inspectdb_fields := tool.get("inspectdb"):
             command._inspectdb_fields = cast(dict[str, str], inspectdb_fields)
+        # The 'init-db' subcommand requires it to not init when aenter
         command._init_when_aenter = False
+        # Call ``command.__aexit__()`` when the context is popped
         ctx.obj["command"] = await ctx.with_async_resource(command)
         _check_aerich_models_included(tortoise_config)
         if invoked_subcommand != "init-db":

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -21,16 +21,15 @@ CONFIG_DEFAULT_VALUES = {
 
 
 def _patch_context_to_close_tortoise_connections_when_exit() -> None:
-    from tortoise import Tortoise, connections
+    if not hasattr(Context, "_patched"):
+        origin_aexit = Context.__aexit__
 
-    origin_aexit = Context.__aexit__
+        async def aexit(*args, **kw) -> None:
+            await origin_aexit(*args, **kw)
+            await Command.aclose()
 
-    async def aexit(*args, **kw) -> None:
-        await origin_aexit(*args, **kw)
-        if Tortoise._inited:
-            await connections.close_all()
-
-    Context.__aexit__ = aexit  # type:ignore[method-assign]
+        Context.__aexit__ = aexit  # type:ignore[method-assign]
+        Context._patched = True  # type:ignore[attr-defined]
 
 
 _patch_context_to_close_tortoise_connections_when_exit()

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -20,22 +20,6 @@ CONFIG_DEFAULT_VALUES = {
 }
 
 
-def _patch_context_to_close_tortoise_connections_when_exit() -> None:
-    if not hasattr(Context, attr := "_tortoise_patched"):
-        func_name = "__aexit__"
-        origin_func = getattr(Context, func_name)
-
-        async def patched(*args, **kw) -> None:
-            await origin_func(*args, **kw)
-            await Command.aclose()
-
-        setattr(Context, func_name, patched)
-        setattr(Context, attr, True)
-
-
-_patch_context_to_close_tortoise_connections_when_exit()
-
-
 def _check_aerich_models_included(tortoise_config: dict) -> None:
     # e.g.: tortoise_config = {'apps': {'app_1': {'models': ['models']}}}
     apps: dict[str, dict[str, list]] = tortoise_config.get("apps", {})
@@ -92,7 +76,8 @@ async def cli(ctx: Context, config: str, app: str) -> None:
         command = Command(tortoise_config=tortoise_config, app=app, location=location)
         if inspectdb_fields := tool.get("inspectdb"):
             command._inspectdb_fields = cast(dict[str, str], inspectdb_fields)
-        ctx.obj["command"] = command
+        command._init_when_aenter = False
+        ctx.obj["command"] = await ctx.with_async_resource(command)
         _check_aerich_models_included(tortoise_config)
         if invoked_subcommand != "init-db":
             if not Path(location, app).exists():

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import platform
 import shlex
 import shutil
 import subprocess
@@ -10,14 +9,14 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests._utils import Dialect, prepare_py_files, requires_dialect
+from tests._utils import WINDOWS, prepare_py_files, requires_dialect
 
 
 def run_aerich(cmd: str) -> subprocess.CompletedProcess | None:
     if not cmd.startswith("poetry") and not cmd.startswith("python"):
         if not cmd.startswith("aerich"):
             cmd = "aerich " + cmd
-        if platform.system() == "Windows":
+        if WINDOWS:
             cmd = "python -m " + cmd
     r = None
     with contextlib.suppress(subprocess.TimeoutExpired):
@@ -45,10 +44,9 @@ def prepare_sqlite_project(tmp_work_dir: Path) -> Generator[tuple[Path, str]]:
     yield models_py, models_py.read_text("utf-8")
 
 
+@requires_dialect("sqlite")
 def test_close_tortoise_connections_patch(tmp_work_dir: Path) -> None:
-    if not Dialect.is_sqlite():
-        return
-    with prepare_sqlite_project(tmp_work_dir) as (models_py, models_text):
+    with prepare_sqlite_project(tmp_work_dir):
         run_aerich("aerich init -t settings.TORTOISE_ORM")
         r = run_aerich("aerich init-db")
         assert r is not None


### PR DESCRIPTION
# Description

1. Remove magic patch for `asyncclick.Context.__aexit__`
2. Use `ctx.with_async_resource` to close db connections when teardown
3. Add aclose to Command class and mark close function as deprecated