### PR TITLE
fix: failed to print subcommand help message

### DIFF
--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from pathlib import Path
 from typing import cast
 
@@ -44,6 +45,9 @@ def _check_aerich_models_included(tortoise_config: dict) -> None:
 @click.option("--app", required=False, help="Tortoise-ORM app name.")
 @click.pass_context
 async def cli(ctx: Context, config: str, app: str) -> None:
+    if any(opt in sys.argv for opt in ctx.help_option_names):
+        # Skip init to print help message
+        return
     ctx.ensure_object(dict)
     ctx.obj["config_file"] = config
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 
 from aerich._compat import tomllib
-from tests._utils import prepare_py_files, requires_dialect, run_shell
+from aerich.cli import inspectdb, upgrade
+from tests._utils import chdir, prepare_py_files, requires_dialect, run_shell
 
 
 @pytest.fixture
@@ -141,3 +142,19 @@ def test_aerich_init() -> None:
     assert "comment-2" in text
     doc = tomllib.loads(text)
     assert doc["tool"]["aerich"]["tortoise_orm"] == "settings.TORTOISE_ORM"
+
+
+def test_help(tmp_path):
+    output = run_shell("aerich --help")
+    assert output == run_shell("aerich -h")
+    assert str(upgrade.help) in output
+    assert "--fake" not in output
+    output = run_shell("aerich upgrade --help")
+    assert output == run_shell("aerich upgrade -h")
+    assert str(upgrade.help) in output
+    assert "--fake" in output
+    with chdir(tmp_path):
+        output = run_shell(f"aerich {inspectdb.name} --help")
+        assert output == run_shell(f"aerich {inspectdb.name} -h")
+        assert str(inspectdb.help) in output
+        assert "--table" in output


### PR DESCRIPTION
# Description

Failed to print help message for some subcommands, for example::

`aerich migrate --help` Got:
```
Usage: aerich [OPTIONS] COMMAND [ARGS]...
Try 'aerich -h' for help.

Error: You need to run `aerich init-db` first to initialize the database.
```
Expected:
```
Usage: aerich migrate [OPTIONS]

  Generate a migration file for the current state of the models.

Options:
  --name TEXT  Migration name.  [default: update]
  --empty      Generate an empty migration file.
  --no-input   Do not ask for prompt.
  -h, --help   Show this message and exit.
```
This PR make it able to print help message for subcommand without trying to init the Command class.