### PR TITLE
refactor: improve fix migrations output message

### DIFF
--- a/aerich/__init__.py
+++ b/aerich/__init__.py
@@ -270,10 +270,10 @@ class Command(TortoiseContext):
     async def init_migrations(self, safe: bool) -> None:
         await self._do_init(safe, offline=True)
 
-    async def fix_migrations(self) -> list[str]:
+    async def fix_migrations(self) -> list[str] | None:
         """
         Fix migration files to include models state for aerich 0.6.0+
-        :return: List of updated migration files
+        :return: List of updated migration files (if no migration file or no aerich objects will return None)
         """
         Migrate.app = self.app
         Migrate.migrate_location = Path(self.location, self.app)

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -407,7 +407,8 @@ async def fix_migrations(ctx: Context) -> None:
     command = ctx.obj["command"]
     updated_files = await command.fix_migrations()
     if updated_files:
-        click.secho(f"Updated {len(updated_files)} migration files:", fg=Color.green)
+        count = len(updated_files)
+        click.secho(f"Updated {count} migration file{'s' * (count > 1)}:", fg=Color.green)
         for file in updated_files:
             click.echo(f"  - {file}")
     elif updated_files is not None:

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -406,15 +406,15 @@ async def inspectdb(ctx: Context, table: list[str]) -> None:
 async def fix_migrations(ctx: Context) -> None:
     command = ctx.obj["command"]
     updated_files = await command.fix_migrations()
-    if not updated_files:
+    if updated_files:
+        click.secho(f"Updated {len(updated_files)} migration files:", fg=Color.green)
+        for file in updated_files:
+            click.echo(f"  - {file}")
+    elif updated_files is not None:
         click.secho(
             "No migration files to update. All files are already in the correct format.",
             fg=Color.green,
         )
-    else:
-        click.secho(f"Updated {len(updated_files)} migration files:", fg=Color.green)
-        for file in updated_files:
-            click.echo(f"  - {file}")
 
 
 def main() -> None:

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable, Literal, cast, overload
 
 import asyncclick as click
@@ -1087,32 +1088,17 @@ class Migrate:
                 cls.downgrade_operators.insert(0, _downgrade_fk_m2m_operator)
 
     @classmethod
-    async def fix_migrations(cls, config: dict[str, Any]) -> list[str]:
+    async def fix_migrations(cls, config: dict[str, Any]) -> list[str] | None:
         """
         Fix old migration files to include MODELS_STATE for aerich 0.9.2+
+
         :return: List of updated migration file paths
         """
         version_modules = cls.get_all_version_modules()
         if not version_modules:
-            return []
-
-        if not Tortoise._inited:
-            await Tortoise.init(config=config)
-        connection = get_app_connection(config, cls.app)
-
-        try:
-            await Aerich.first().values("id")
-        except OperationalError:
-            click.secho(
-                "⚠️ Warning: Aerich table not found. "
-                "fix-migrations can only be applied by using "
-                "existing database with all migrations applied.",
-                fg=Color.yellow,
-            )
-            return []
-        updated_files: list[str] = []
-
-        # Get model state from Aerich table for each migration
+            click.echo(f"No migration file found for app {cls.app!r}, nothing to do.")
+            return None
+        unfixed_file_modules: list[tuple[str, ModuleType]] = []
         for version_module in version_modules:
             # Check if file already has MODELS_STATE
             migration_info = import_py_module(version_module)
@@ -1120,11 +1106,41 @@ class Migrate:
                 # File is already in the new format
                 continue
             file_name = version_module.name + ".py"
-            file_path = cls.migrate_location / file_name
+            unfixed_file_modules.append((file_name, migration_info))
+        if not unfixed_file_modules:
+            return []
 
+        if not Tortoise._inited:
+            await Tortoise.init(config=config)
+        connection = get_app_connection(config, cls.app)
+
+        try:
+            fid = await Aerich.first().values("id")
+        except OperationalError:
+            click.secho(
+                "⚠️ Warning: Aerich table not found. "
+                "fix-migrations can only be applied by using "
+                "existing database with all migrations applied.",
+                fg=Color.yellow,
+            )
+            return None
+        if not fid:  # Aerich.all().count() == 0
+            click.secho(
+                "⚠️ Warning: Aerich table is empty. "
+                "fix-migrations can only be applied by using "
+                "existing database with all migrations applied.",
+                fg=Color.yellow,
+            )
+            return None
+
+        updated_files: list[str] = []
+
+        # Get model state from Aerich table for each migration
+        for file_name, migration_info in unfixed_file_modules:
+            file_path = cls.migrate_location / file_name
             # Find the corresponding record in the Aerich table
-            aerich_models = await Aerich.filter(version=file_name, app=cls.app).first()
-            if not aerich_models:
+            aerich_obj = await Aerich.filter(version=file_name, app=cls.app).first()
+            if aerich_obj is None:
                 click.secho(
                     f"⚠️ Warning: No matching record for migration {file_name} in Aerich table. Skipping.",
                     fg=Color.yellow,
@@ -1132,7 +1148,7 @@ class Migrate:
                 continue
 
             # Get models state from the content column
-            models_state = aerich_models.content
+            models_state = aerich_obj.content
             if not models_state:
                 click.secho(
                     f"⚠️ Warning: No content found for migration {file_name}. Skipping.",

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import os
 import shlex
@@ -11,19 +12,20 @@ from pathlib import Path
 
 from tortoise import Tortoise
 
-from aerich import Command, decompress_dict, import_py_file
+from aerich import Command, Migrate, TortoiseContext, decompress_dict, import_py_file
 from aerich.models import Aerich
-from aerich.utils import load_tortoise_config, run_async
-from tests._utils import WINDOWS, prepare_py_files, requires_dialect
+from aerich.utils import get_app_connection, load_tortoise_config, run_async
+from tests._utils import ASSETS, WINDOWS, prepare_py_files, requires_dialect
 
 
-def run_aerich(cmd: str) -> subprocess.CompletedProcess:
+def run_aerich(cmd: str, capture_output=False) -> subprocess.CompletedProcess:
     if not cmd.startswith("poetry") and not cmd.startswith("python"):
         if not cmd.startswith("aerich"):
             cmd = "aerich " + cmd
         if WINDOWS:
             cmd = "python -m " + cmd
-    r = subprocess.run(shlex.split(cmd), timeout=2)
+    run_cmd = functools.partial(subprocess.run, shlex.split(cmd), timeout=2)
+    r = run_cmd(capture_output=True, encoding="utf-8") if capture_output else run_cmd()
     return r
 
 
@@ -160,6 +162,56 @@ def test_sqlite_fix_migrations(tmp_work_dir: Path) -> None:
 
         created_migrations = migrations_dir.glob("*.py")
         assert len(list(created_migrations)) == 3, created_migrations
+
+        message = "No migration files to update. All files are already in the correct format."
+        r = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message in r.stdout
+
+        for p in migrations_dir.glob("*.py"):
+            p.unlink()
+        if (pycache := migrations_dir / "__pycache__").exists():
+            shutil.rmtree(pycache)
+        r2 = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message not in r2.stdout
+        assert "No migration file found for app 'models', nothing to do." in r2.stdout
+
+        shutil.rmtree(migrations_dir)
+        r3 = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message not in r3.stdout
+        assert "No migration file found for app 'models', nothing to do." in r3.stdout
+
+        asset_dir = ASSETS / "sqlite_old_style"
+        migrations_source = asset_dir / "_migrations"
+        shutil.copytree(migrations_source / "models", migrations_dir)
+
+        async def delete_first_aerich():
+            async with TortoiseContext():
+                await Aerich.filter(version__startswith="0").delete()
+
+        run_async(delete_first_aerich)
+        r4 = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message not in r4.stdout
+        assert "Warning: No matching record for migration" in r4.stdout
+
+        async def remove_aerich_records():
+            async with TortoiseContext():
+                await Aerich.all().delete()
+
+        run_async(remove_aerich_records)
+        r5 = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message not in r5.stdout
+        assert "Warning: Aerich table is empty." in r5.stdout
+
+        async def drop_aerich_table():
+            async with TortoiseContext():
+                conn = get_app_connection(load_tortoise_config(), "models")
+                sql = Migrate.drop_model("aerich")
+                await conn.execute_script(sql)
+
+        run_async(drop_aerich_table)
+        r6 = run_aerich("aerich fix-migrations", capture_output=True)
+        assert message not in r6.stdout
+        assert "Warning: Aerich table not found." in r6.stdout
 
 
 M2M_WITH_CUSTOM_THROUGH = """


### PR DESCRIPTION
# Description

When I have an empty migrations/ directory or empty aerich table, run `aerich fix-migrations` print message: "No migration files to update. All files are already in the correct format."

So I change return value of the `fix_migrations` function from `list[str]` to `list[str] | None`, if return value is None, the message above will not print.