### PR TITLE
refactor: warning not handle attribute changes with field name

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -403,6 +403,8 @@ class Migrate:
             if action == "change":
                 # Example:: action = 'change'; option = [0, 'unique']; change = (False, True)
                 attr = option[-1]
+                field_name = option[0]
+                full_name = f"{model._meta.full_name}.{field_name}"
                 if attr == "indexed":
                     # Ignore changing of indexed, as it usually changed by unique
                     continue
@@ -413,7 +415,7 @@ class Migrate:
                     # TODO: handle 'unique'
                     if upgrade:
                         click.secho(
-                            f"Aerich does not handle {attr!r} attribution for m2m field. You may need to change the constraints in db manually.",
+                            f"Aerich does not handle {attr!r} attribution for m2m field({full_name}). You may need to change the constraints in db manually.",
                             fg=Color.yellow,
                         )
                     continue

--- a/aerich/utils.py
+++ b/aerich/utils.py
@@ -237,6 +237,16 @@ def py_module_path(module_info: pkgutil.ModuleInfo) -> Path:
     return Path(spec.origin)
 
 
+def _get_field_diffs(old_field: dict, new_field: dict) -> Generator:
+    """Get diffs with field name"""
+    changes = list(diff([old_field], [new_field]))
+    if changes:
+        field_name = new_field.get("name") or old_field.get("name", "")
+        for c in changes:
+            c[1][0] = field_name
+    yield from changes
+
+
 def get_dict_diff_by_key(
     old_fields: list[dict],
     new_fields: list[dict],
@@ -264,8 +274,10 @@ def get_dict_diff_by_key(
 
     """
     length_old, length_new = len(old_fields), len(new_fields)
-    if length_old == 0 or length_new == 0 or length_old == length_new == 1:
+    if length_old == 0 or length_new == 0:
         yield from diff(old_fields, new_fields)
+    elif length_old == length_new == 1:
+        yield from _get_field_diffs(old_fields[0], new_fields[0])
     else:
         should_use_second_key = len({i[key] for i in old_fields}) < length_old or (
             len({i[key] for i in new_fields}) < length_new
@@ -280,7 +292,7 @@ def get_dict_diff_by_key(
             value = (field[key], field[second_key]) if should_use_second_key else field[key]
             if (index := value_index.get(value)) is not None:
                 additions.remove(index)
-                yield from diff([field], [new_fields[index]])  # change
+                yield from _get_field_diffs(field, new_fields[index])  # change
             else:
                 yield from diff([field], [])  # remove
         if additions:

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -985,7 +985,7 @@ def test_migrate(mocker: MockerFixture, capsys):
         Migrate.diff_models(old_models_describe, models_describe)
         Migrate.diff_models(models_describe, old_models_describe, False)
         Migrate._merge_operators()
-    warning_msg = "Aerich does not handle 'unique' attribution for m2m field. You may need to change the constraints in db manually."
+    warning_msg = "Aerich does not handle 'unique' attribution for m2m field(models.Category.products). You may need to change the constraints in db manually."
     if isinstance(Migrate.ddl, MysqlDDL):
         expected_upgrade_operators = {
             "ALTER TABLE `category` MODIFY COLUMN `name` VARCHAR(200)",

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,11 +20,12 @@ from tests._utils import ASSETS, WINDOWS, prepare_py_files, requires_dialect
 
 
 def run_aerich(cmd: str, capture_output=False) -> subprocess.CompletedProcess:
-    if not cmd.startswith("poetry") and not cmd.startswith("python"):
+    if not cmd.startswith("uv") and not cmd.startswith("python") and "-m aerich " not in cmd:
         if not cmd.startswith("aerich"):
             cmd = "aerich " + cmd
         if WINDOWS:
-            cmd = "python -m " + cmd
+            py = Path(sys.executable).as_posix()
+            cmd = f"{py} -m " + cmd
     run_cmd = functools.partial(subprocess.run, shlex.split(cmd), timeout=2)
     r = run_cmd(capture_output=True, encoding="utf-8") if capture_output else run_cmd()
     return r

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,7 +62,7 @@ class TestDiffFields:
         diffs = list(get_dict_diff_by_key(old, new))
         assert type(get_dict_diff_by_key(old, new)).__name__ == "generator"
         assert len(diffs) == 1
-        assert diffs == [("change", [0, "name"], ("users", "members"))]
+        assert diffs == [("change", ["members", "name"], ("users", "members"))]
 
     def test_same_through_with_different_orders(self) -> None:
         old = [
@@ -75,7 +75,7 @@ class TestDiffFields:
         ]
         diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 1
-        assert diffs == [("change", [0, "name"], ("users", "members"))]
+        assert diffs == [("change", ["members", "name"], ("users", "members"))]
 
     def test_the_same_field_name_order(self) -> None:
         old = [
@@ -182,8 +182,8 @@ class TestDiffFields:
         diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 3
         assert diffs == [
-            ("change", [0, "name"], ("staffs", "staffs_new")),
-            ("change", [0, "name"], ("admins", "admins_new")),
+            ("change", ["staffs_new", "name"], ("staffs", "staffs_new")),
+            ("change", ["admins_new", "name"], ("admins", "admins_new")),
             ("add", "", [(0, {"name": "users", "through": "users_group"})]),
         ]
 
@@ -201,9 +201,9 @@ class TestDiffFields:
         diffs = list(get_dict_diff_by_key(old, new))
         assert len(diffs) == 3
         assert diffs == [
-            ("change", [0, "name"], ("staffs", "staffs_new")),
-            ("change", [0, "name"], ("admins", "admins_new")),
-            ("change", [0, "name"], ("users", "users_new")),
+            ("change", ["staffs_new", "name"], ("staffs", "staffs_new")),
+            ("change", ["admins_new", "name"], ("admins", "admins_new")),
+            ("change", ["users_new", "name"], ("users", "users_new")),
         ]
 
     def test_use_second_key(self) -> None:


### PR DESCRIPTION
# Description

It's better to show changes of which field was ignored, e.g.:
- Currently
```
Aerich does not handle 'unique' attribution for m2m field. You may need to change the constraints in db manually.
```
- After PR merged
```
Aerich does not handle 'unique' attribution for m2m field(models.Users.friends). You may need to change the constraints in db manually.
```
