### PR TITLE
Add justfile to support development commands on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           activate-environment: true
+      - name: Install just via uv
+        run: |
+          uv tool install rust-just
+          echo "$(uv tool dir --bin)" >> "$GITHUB_PATH"
       - name: Check code style and Type Hints
-        run: make check
+        run: just check
 
   ci:
     runs-on: ubuntu-latest
@@ -67,8 +71,15 @@ jobs:
         with:
           enable-cache: true
           activate-environment: true
+      - name: Install just via pipx
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pipx
+          pipx install rust-just
+          pipx ensurepath
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
-        run: make deps options='--no-extra=psycopg'
+        run: just deps '--no-extra=psycopg'
       - name: Install TortoiseORM v0.21
         if: matrix.tortoise-orm == 'tortoise021'
         run: |
@@ -97,23 +108,23 @@ jobs:
         run: uv pip install --upgrade "tortoise-orm<1.2"
       - name: Run tests for postgres
         run:
-          make test_postgres
+          just test_postgres
         env:
           POSTGRES_PASS: 123456
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_PORT: 5432
       - name: Run tests for mysql
         run:
-          make test_mysql
+          just test_mysql
         env:
           MYSQL_PASS: root
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
       - name: Run tests for sqlite
         run:
-          make test_sqlite
+          just test_sqlite
       - name: Show test coverage
-        run: make report
+        run: just report
 
   nuitkaSupport:
     runs-on: ubuntu-latest
@@ -131,9 +142,11 @@ jobs:
         with:
           enable-cache: true
           activate-environment: true
+      - name: Install just via taiki-e/install-action
+        uses: taiki-e/install-action@just
       - name: Install dependencies
         run: |
-          make deps options='--no-dev --no-group test'
+          just deps '--no-dev --no-group test'
           uv pip install nuitka
           sudo apt install -y patchelf
       - name: Run tests for nuitka
@@ -157,10 +170,12 @@ jobs:
           enable-cache: true
           python-version: '3.13'
           activate-environment: true
+      - name: Install just via setup-just
+        uses: extractions/setup-just@v3
       - name: Install dependencies
         run: uv sync --group test --extra toml --extra asyncmy
       - name: Test MySQL with asyncmy
-        run: make test_mysql
+        run: just test_mysql
         env:
           MYSQL_PASS: root
           MYSQL_HOST: 127.0.0.1
@@ -168,7 +183,7 @@ jobs:
           # Verify `poetry add aerich` work
           AERICH_TEST_POETRY_ADD: 1
       - name: Show test coverage
-        run: make report
+        run: just report
 
   postgresVector:
     runs-on: ubuntu-latest
@@ -189,16 +204,20 @@ jobs:
           enable-cache: true
           python-version: '3.13'
           activate-environment: true
+      - name: Install just via apt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
       - name: Install dependencies
         run: uv pip install --group vector --group test -e ".[toml,mysql]"
       - name: Test tortoise vector
-        run: make test_postgres_vector
+        run: just test_postgres_vector
         env:
           POSTGRES_PASS: 123456
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_PORT: 5432
       - name: Show test coverage
-        run: make report
+        run: just report
 
   psycopgSupport:
     runs-on: ${{ matrix.os }}
@@ -219,14 +238,26 @@ jobs:
         with:
           enable-cache: true
           activate-environment: true
+      - name: Install just via apt
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+      # Windows alternatives:
+      #   winget install --id Casey.Just --exact
+      #   uv tool install rust-just
+      #   pipx install rust-just
+      - name: Install just via Chocolatey
+        if: runner.os == 'Windows'
+        run: choco install just -y
       - name: Install dependencies
         run: |
           uv pip install --group test -e ".[toml,psycopg,mysql]"
       - name: Test psycopg
-        run: make test_psycopg
+        run: just test_psycopg
         env:
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_PASS: 123456
           POSTGRES_PORT: 5432
       - name: Show test coverage
-        run: make report
+        run: just report

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           python-version: '3.x'
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: extractions/setup-just@v3
       - name: Build dists
         run: make build
       - name: Pypi Publish

--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,80 @@
-src_dir = aerich
-checkfiles = $(src_dir) tests/ conftest.py
-py_warn = PYTHONDEVMODE=1
-pytest_opts = --cov=$(src_dir) --cov-append --tb=native -q
-MYSQL_HOST ?= "127.0.0.1"
+JUST_INSTALL_HINT = The 'just' command is required. Install it with: uv tool install rust-just
+.DEFAULT_GOAL := up
+
+MYSQL_HOST ?= 127.0.0.1
 MYSQL_PORT ?= 3306
-MYSQL_PASS ?= "123456"
-POSTGRES_HOST ?= "127.0.0.1"
+MYSQL_PASS ?= 123456
+POSTGRES_HOST ?= 127.0.0.1
 POSTGRES_PORT ?= 5432
 POSTGRES_PASS ?= 123456
 
-up:
-	@uv lock --upgrade
+.PHONY: ensure-just up deps _style style _codeqc codeqc _check check _lint lint test test_sqlite test_mysql test_postgres test_postgres_vector test_psycopg _testall testall report _build build ci
 
-deps:
-	@uv sync --all-extras --all-groups --no-extra asyncmy --no-group=vector $(options)
+ensure-just:
+	@command -v just >/dev/null 2>&1 || (echo "$(JUST_INSTALL_HINT)" >&2; exit 1)
 
-_style:
-	@ruff format $(checkfiles)
-	@ruff check --fix $(checkfiles)
-style: deps _style
+up: ensure-just
+	@just up
 
-_codeqc:
-	uv run --no-sync mypy $(checkfiles)
-	uv run --no-sync bandit -c pyproject.toml -r $(checkfiles)
-	uv run --no-sync twine check dist/*
-codeqc: build _codeqc
+deps: ensure-just
+	@just deps "$(options)"
 
-_check: _build
-	@ruff format --check $(checkfiles) || (echo "Please run 'make style' to auto-fix style issues" && false)
-	@ruff check $(checkfiles)
-	$(MAKE) _codeqc
-check: deps _check
+_style: ensure-just
+	@just _style
 
-_lint: _build _style _codeqc
-lint: deps _lint
+style: ensure-just
+	@just style
 
-test: deps
-	$(py_warn) uv run --no-sync pytest $(pytest_opts)
+_codeqc: ensure-just
+	@just _codeqc
 
-test_sqlite:
-	$(py_warn) TEST_DB=sqlite://:memory: uv run --no-sync pytest $(pytest_opts)
+codeqc: ensure-just
+	@just codeqc
 
-test_mysql:
-	$(py_warn) TEST_DB="mysql://root:$(MYSQL_PASS)@$(MYSQL_HOST):$(MYSQL_PORT)/test_\{\}" uv run --no-sync pytest -vv -s $(pytest_opts)
+_check: ensure-just
+	@just _check
 
-test_postgres:
-	$(py_warn) TEST_DB="postgres://postgres:$(POSTGRES_PASS)@$(POSTGRES_HOST):$(POSTGRES_PORT)/test_\{\}" uv run --no-sync pytest -vv -s $(pytest_opts)
+check: ensure-just
+	@just check
 
-test_postgres_vector:
-	$(py_warn) AERICH_TEST_VECTOR=1 TEST_DB="postgres://postgres:$(POSTGRES_PASS)@$(POSTGRES_HOST):$(POSTGRES_PORT)/test_\{\}" uv run --no-sync pytest -vv -s tests/test_inspectdb.py::test_inspect_vector $(pytest_opts)
+_lint: ensure-just
+	@just _lint
 
-test_psycopg:
-	$(py_warn) TEST_DB="psycopg://postgres:$(POSTGRES_PASS)@$(POSTGRES_HOST):$(POSTGRES_PORT)/test_\{\}" uv run --no-sync pytest -vv -s $(pytest_opts)
+lint: ensure-just
+	@just lint
 
-_testall: test_sqlite test_postgres test_mysql
-testall: deps _testall
+test: ensure-just
+	@just test
 
-report:
-	uv run --no-sync coverage report -m
+test_sqlite: ensure-just
+	@just test_sqlite
 
-_build:
-	uv build --offline
+test_mysql: ensure-just
+	@MYSQL_HOST="$(MYSQL_HOST)" MYSQL_PORT="$(MYSQL_PORT)" MYSQL_PASS="$(MYSQL_PASS)" just test_mysql
 
-build: deps
-	uv build
+test_postgres: ensure-just
+	@POSTGRES_HOST="$(POSTGRES_HOST)" POSTGRES_PORT="$(POSTGRES_PORT)" POSTGRES_PASS="$(POSTGRES_PASS)" just test_postgres
 
-ci: build _check _testall
+test_postgres_vector: ensure-just
+	@POSTGRES_HOST="$(POSTGRES_HOST)" POSTGRES_PORT="$(POSTGRES_PORT)" POSTGRES_PASS="$(POSTGRES_PASS)" just test_postgres_vector
+
+test_psycopg: ensure-just
+	@POSTGRES_HOST="$(POSTGRES_HOST)" POSTGRES_PORT="$(POSTGRES_PORT)" POSTGRES_PASS="$(POSTGRES_PASS)" just test_psycopg
+
+_testall: ensure-just
+	@just _testall
+
+testall: ensure-just
+	@just testall
+
+report: ensure-just
+	@just report
+
+_build: ensure-just
+	@just _build
+
+build: ensure-just
+	@just build
+
+ci: ensure-just
+	@just ci

--- a/justfile
+++ b/justfile
@@ -17,8 +17,8 @@ psycopg_url := "psycopg://" + postgres_test_uri
 default:
     @just --list
 
-up:
-    uv lock --upgrade
+up *args:
+    uv lock --upgrade {{ args }}
 
 deps options="":
     uv sync --all-extras --all-groups --no-extra asyncmy --no-group=vector {{ options }}
@@ -58,8 +58,8 @@ _lint: _build _style _codeqc
 
 lint: deps _lint
 
-test: deps
-    just _pytest
+test *args: deps
+    just _pytest {{ args }}
 
 test_sqlite:
     just _pytest_env TEST_DB "sqlite://:memory:"
@@ -102,7 +102,7 @@ testall: deps _testall
 report:
     uv run --no-sync coverage report -m
 
-build: deps
-    uv build
+build *args: deps
+    uv build {{ args }}
 
 ci: build _check _testall

--- a/justfile
+++ b/justfile
@@ -16,17 +16,17 @@ up:
 deps options="":
     uv sync --all-extras --all-groups --no-extra asyncmy --no-group=vector {{ options }}
 
-_style files=(checkfiles) *args:
-    just _ruff format {{ files }} {{ args }}
-    just _ruff check {{ files }} --fix {{ args }}
+_style *args:
+    just _ruff format {{ checkfiles }} {{ args }}
+    just _ruff check {{ checkfiles }} --fix {{ args }}
 
 [unix]
-_ruff command files=(checkfiles) *args:
-    uv run --no-sync ruff {{ command }} {{ files }} {{ args }}
+_ruff command *args:
+    uv run --no-sync ruff {{ command }} {{ args }}
 
 [windows]
-_ruff command files=(checkfiles) *args:
-    uv run --no-sync ruff {{ command }} --force-exclude --exclude tests/assets {{ files }} {{ args }}
+_ruff command *args:
+    uv run --no-sync ruff {{ command }} --force-exclude --exclude tests/assets {{ args }}
 
 style: deps _style
 

--- a/justfile
+++ b/justfile
@@ -3,9 +3,9 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 src_dir := "aerich"
 checkfiles := "aerich tests/ conftest.py"
 pytest_opts := "--cov=aerich --cov-append --tb=native -q"
-mysql_url := "mysql://root:" + env_var_or_default("MYSQL_PASS", "123456") + "@" + env_var_or_default("MYSQL_HOST", "127.0.0.1") + ":" + env_var_or_default("MYSQL_PORT", "3306") + "/test_{}"
-postgres_url := "postgres://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_{}"
-psycopg_url := "psycopg://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_{}"
+mysql_url := "mysql://root:" + env_var_or_default("MYSQL_PASS", "123456") + "@" + env_var_or_default("MYSQL_HOST", "127.0.0.1") + ":" + env_var_or_default("MYSQL_PORT", "3306") + "/test_\\{\\}"
+postgres_url := "postgres://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_\\{\\}"
+psycopg_url := "psycopg://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_\\{\\}"
 
 default:
     @just --list

--- a/justfile
+++ b/justfile
@@ -1,0 +1,101 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+src_dir := "aerich"
+checkfiles := "aerich tests/ conftest.py"
+pytest_opts := "--cov=aerich --cov-append --tb=native -q"
+mysql_url := "mysql://root:" + env_var_or_default("MYSQL_PASS", "123456") + "@" + env_var_or_default("MYSQL_HOST", "127.0.0.1") + ":" + env_var_or_default("MYSQL_PORT", "3306") + "/test_{}"
+postgres_url := "postgres://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_{}"
+psycopg_url := "psycopg://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_{}"
+
+default:
+    @just --list
+
+up:
+    uv lock --upgrade
+
+deps options="":
+    uv sync --all-extras --all-groups --no-extra asyncmy --no-group=vector {{ options }}
+
+_style files=(checkfiles) *args:
+    just _ruff format {{ files }} {{ args }}
+    just _ruff check {{ files }} --fix {{ args }}
+
+[unix]
+_ruff command files=(checkfiles) *args:
+    uv run --no-sync ruff {{ command }} {{ files }} {{ args }}
+
+[windows]
+_ruff command files=(checkfiles) *args:
+    uv run --no-sync ruff {{ command }} --force-exclude --exclude tests/assets {{ files }} {{ args }}
+
+style: deps _style
+
+_codeqc:
+    uv run --no-sync mypy {{ checkfiles }}
+    uv run --no-sync bandit -c pyproject.toml -r {{ checkfiles }}
+    uv run --no-sync twine check dist/*
+
+codeqc: build _codeqc
+
+_build:
+    uv build --offline
+
+_check: _build
+    just _ruff format {{ checkfiles }} --check
+    just _ruff check {{ checkfiles }}
+    just _codeqc
+
+check: deps _check
+
+_lint: _build _style _codeqc
+
+lint: deps _lint
+
+test: deps
+    just _pytest
+
+test_sqlite:
+    just _pytest_env TEST_DB "sqlite://:memory:"
+
+test_mysql:
+    just _pytest_env TEST_DB "{{ mysql_url }}" -vv -s
+
+test_postgres:
+    just _pytest_env TEST_DB "{{ postgres_url }}" -vv -s
+
+test_postgres_vector:
+    just _pytest_vector "{{ postgres_url }}" -vv -s tests/test_inspectdb.py::test_inspect_vector
+
+test_psycopg:
+    just _pytest_env TEST_DB "{{ psycopg_url }}" -vv -s
+
+_pytest *args:
+    uv run --no-sync pytest {{ args }} {{ pytest_opts }}
+
+[unix]
+_pytest_env env_name env_value *args:
+    {{ env_name }}='{{ env_value }}' uv run --no-sync pytest {{ args }} {{ pytest_opts }}
+
+[windows]
+_pytest_env env_name env_value *args:
+    $env:{{ env_name }} = '{{ env_value }}'; uv run --no-sync pytest {{ args }} {{ pytest_opts }}
+
+[unix]
+_pytest_vector db_url *args:
+    AERICH_TEST_VECTOR=1 TEST_DB='{{ db_url }}' uv run --no-sync pytest {{ args }} {{ pytest_opts }}
+
+[windows]
+_pytest_vector db_url *args:
+    $env:AERICH_TEST_VECTOR = '1'; $env:TEST_DB = '{{ db_url }}'; uv run --no-sync pytest {{ args }} {{ pytest_opts }}
+
+_testall: test_sqlite test_postgres test_mysql
+
+testall: deps _testall
+
+report:
+    uv run --no-sync coverage report -m
+
+build: deps
+    uv build
+
+ci: build _check _testall

--- a/justfile
+++ b/justfile
@@ -1,11 +1,18 @@
+#!/usr/bin/env -S just --justfile
+# ^ A shebang isn't required, but allows a justfile to be executed
+#   like a script, with `./justfile lint`, for example.
+# Use powershell for Windows so that 'Git Bash' and 'PyCharm Terminal' get the same result
+
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
 src_dir := "aerich"
-checkfiles := "aerich tests/ conftest.py"
+checkfiles := src_dir + " tests/ conftest.py"
 pytest_opts := "--cov=aerich --cov-append --tb=native -q"
-mysql_url := "mysql://root:" + env_var_or_default("MYSQL_PASS", "123456") + "@" + env_var_or_default("MYSQL_HOST", "127.0.0.1") + ":" + env_var_or_default("MYSQL_PORT", "3306") + "/test_\\{\\}"
-postgres_url := "postgres://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_\\{\\}"
-psycopg_url := "psycopg://postgres:" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + "/test_\\{\\}"
+test_db := "/test_\\{\\}"
+mysql_url := "mysql://root:" + env_var_or_default("MYSQL_PASS", "123456") + "@" + env_var_or_default("MYSQL_HOST", "127.0.0.1") + ":" + env_var_or_default("MYSQL_PORT", "3306") + test_db
+postgres_test_uri := env_var_or_default("POSTGRES_USER", "postgres") + ":" + env_var_or_default("POSTGRES_PASS", "123456") + "@" + env_var_or_default("POSTGRES_HOST", "127.0.0.1") + ":" + env_var_or_default("POSTGRES_PORT", "5432") + test_db
+postgres_url := "postgres://" + postgres_test_uri
+psycopg_url := "psycopg://" + postgres_test_uri
 
 default:
     @just --list


### PR DESCRIPTION
## Summary

This PR adds a `justfile` as a cross-platform alternative to the existing `Makefile`, so development commands such as linting, formatting, building, and testing can be run on Windows as well as Linux/macOS.

The existing `Makefile` is kept as a compatibility wrapper and now delegates to `just`, with an install hint when `just` is missing.

## Changes

- Add `justfile` with recipes mirroring the existing Makefile targets:
  - `just style`
  - `just check`
  - `just lint`
  - `just test_sqlite`
  - `just test_mysql`
  - `just test_postgres`
  - `just test_postgres_vector`
  - `just test_psycopg`
  - `just build`
  - `just ci`
- Keep `make ...` commands working by delegating Makefile targets to `just ...`.
- Update CI to use `just` commands directly.
- Keep the PyPI workflow using `make build`, while installing `just` first so the Makefile wrapper works.
- Add Windows-specific handling in the `justfile` for shell environment variables and Ruff path exclusions.

## Installing just

`just` can be installed in several common ways:

- uv: `uv tool install rust-just`
- pipx: `pipx install rust-just`
- Cargo: `cargo install just`
- apt: `sudo apt-get install just`
- Chocolatey: `choco install just -y`
- winget: `winget install --id Casey.Just --exact`
- GitHub Actions: `extractions/setup-just@v3`
- GitHub Actions: `taiki-e/install-action@just`

## Validation

Ran successfully on Windows:

- `just --list`
- `just --unstable --fmt --check`
- `just _style`
- `just _check`
- `just test_sqlite`